### PR TITLE
Add eCLM to TSMP 

### DIFF
--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -204,9 +204,17 @@ setCombination(){
     withOAS="true"
     case "$version" in *MCT*) withOASMCT="true" ;; esac
   fi
+
+  # workaround to enable OASIS3-MCT build for eCLM without checking
+  # for COSMO/ICON/Parflow. MCT is a hard dependency of eCLM.
+  if [[ $withCLM == "true" && $mList[1] == "eclm" ]] ; then
+    case "$version" in *MCT*)
+      withOAS="true"
+      withOASMCT="true" ;;
+    esac
+  fi
 #DA
   case "$version" in *PDAF*) withDA="true" ; withPDAF="true" ;; esac
-
 }
 
 
@@ -221,9 +229,9 @@ route "${cyellow}> c_compileClm${cnormal}"
     if [[ ${options["clm"]} == "fresh" ]] ; then
       if [[ ${mList[1]} == "eclm" ]] ; then
         rm -rf $clmdir >> $log_file 2>> $err_file
+        comment "   Cloning eCLM from https://github.com/HPSCTerrSys/eCLM.git"
         git clone https://github.com/HPSCTerrSys/eCLM.git $clmdir >> $log_file 2>> $err_file
         check
-        comment "  eCLM successfully cloned from https://github.com/HPSCTerrSys/eCLM.git \n"
       else
         comment "  backup clm dir to: $clmdir"
         rm -rf $clmdir >> $log_file 2>> $err_file

--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -218,15 +218,17 @@ route "${cyellow}> c_compileClm${cnormal}"
   check
     always_clm
     if [[ ${options["clm"]} == "skip" ]] ; then ; route "${cyellow}< c_compileClm${cnormal}" ; return  ;fi 
-    if [[ ${options["clm"]} == "fresh" ]] ; then 
-  comment "  backup clm dir to: $clmdir"
-      rm -rf $clmdir >> $log_file 2>> $err_file
-  check
-    # remove '-icon' from the mList[1] name
-    clmicon="${mList[1]}"
-    clmicon=${clmicon%'-icon'}
-    cp -rf ${rootdir}/${clmicon} $clmdir >> $log_file 2>> $err_file
-  check
+    if [[ ${options["clm"]} == "fresh" ]] ; then
+      if [ -d $clmdir ] ; then
+        comment "  backup clm dir to: $clmdir"
+        rm -rf $clmdir >> $log_file 2>> $err_file
+        check
+        # remove '-icon' from the mList[1] name
+        clmicon="${mList[1]}"
+        clmicon=${clmicon%'-icon'}
+        cp -rf ${rootdir}/${clmicon} $clmdir >> $log_file 2>> $err_file
+        check
+      fi
     fi
     if [[ ${options["clm"]} == "build" || ${options["clm"]} == "fresh" ]] ; then
       substitutions_clm

--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -219,7 +219,12 @@ route "${cyellow}> c_compileClm${cnormal}"
     always_clm
     if [[ ${options["clm"]} == "skip" ]] ; then ; route "${cyellow}< c_compileClm${cnormal}" ; return  ;fi 
     if [[ ${options["clm"]} == "fresh" ]] ; then
-      if [ -d $clmdir ] ; then
+      if [[ ${mList[1]} == "eclm" ]] ; then
+        rm -rf $clmdir >> $log_file 2>> $err_file
+        git clone https://github.com/HPSCTerrSys/eCLM.git $clmdir >> $log_file 2>> $err_file
+        check
+        comment "  eCLM successfully cloned from https://github.com/HPSCTerrSys/eCLM.git \n"
+      else
         comment "  backup clm dir to: $clmdir"
         rm -rf $clmdir >> $log_file 2>> $err_file
         check

--- a/bldsva/intf_oas3/common_build_interface.ksh
+++ b/bldsva/intf_oas3/common_build_interface.ksh
@@ -771,47 +771,60 @@ route "${cyellow}<<< c_setup_clm${cnormal}"
 
 
 c_configure_eclm(){
-route "${cyellow}>>> c_configure_clm${cnormal}"
+route "${cyellow}>>> c_configure_eclm${cnormal}"
   comment "    Using land component model eCLM (experimental) \n"
-  comment "    Checking if eCLM repo is valid..."
+  comment "    Checking if eCLM repo is valid"
   cd ${clmdir}
   git status >> $log_file 2>> $err_file
   check
+
+  if [[ -z $ECLM_CC || "$ECLM_CC" == " " ]]; then
+    ECLM_CC=mpicc
+  fi
+  if [[ -z $ECLM_FC || "$ECLM_FC" == " " ]]; then
+    ECLM_FC=mpifort
+  fi
+
+  if [[ $withOASMCT == "true" ]]; then
+    comment "    MCT build flags will be enabled.\n"
+    ECLM_CMAKE_VARS+=" -DBUILD_MCT=TRUE"
+    ECLM_CMAKE_VARS+=" -DCMAKE_PREFIX_PATH="$oasdir/$platform""
+  fi
+
   comment "    Running CMake configure step..."
-  ECLM_BUILD_DIR=${clmdir}/build >> $log_file 2>> $err_file
-  timer_start=$(date +%s)
-  cmake -S src -B "${ECLM_BUILD_DIR}" \
-      -DCMAKE_INSTALL_PREFIX="$bindir" \
-      -DCMAKE_C_COMPILER=mpicc \
-      -DCMAKE_Fortran_COMPILER=mpifort >> $log_file 2>> $err_file
+  ECLM_BUILD_DIR="$clmdir/build"
+  cmake -S src -B "$ECLM_BUILD_DIR" \
+    -DCMAKE_INSTALL_PREFIX="$bindir" \
+    -DCMAKE_C_COMPILER=$ECLM_CC \
+    -DCMAKE_Fortran_COMPILER=$ECLM_FC \
+     $ECLM_CMAKE_VARS >> $log_file 2>> $err_file
   check
-  timer_end=$(date +%s)
-  comment "    Configure step took $(date -u -d "0 $timer_end sec - $timer_start sec" +"%S") seconds\n"
-route "${cyellow}<<< c_configure_clm${cnormal}"
+
+route "${cyellow}<<< c_configure_eclm${cnormal}"
 }
 
 c_make_eclm(){
-  route "${cyellow}>>> c_make_clm${cnormal}"
-  comment "    Building eCLM..."
+route "${cyellow}>>> c_make_eclm${cnormal}"
+  comment "    Building eCLM (this will take approximately 30 mins)..."
   timer_start=$(date +%s)
   cmake --build "$ECLM_BUILD_DIR" >> $log_file 2>> $err_file
   check
   timer_end=$(date +%s)
-  comment "    Build succeeded! Build duration: $(date -u -d "0 $timer_end sec - $timer_start sec" +"%H:%M:%S")\n"
-  comment "    Installing eCLM..."
+  comment "    Build duration: $(date -u -d "0 $timer_end sec - $timer_start sec" +"%H:%M:%S")\n"
+  comment "    Installing eCLM"
   cmake --install "$ECLM_BUILD_DIR" >> $log_file 2>> $err_file
   check
-  route "${cyellow}<<< c_make_clm${cnormal}"
+route "${cyellow}<<< c_make_eclm${cnormal}"
 }
 
 c_substitutions_clm(){
-route "${cyellow}>>> c_substitutions_clm${cnormal}"
-route "${cyellow}<<< c_substitutions_clm${cnormal}"
+route "${cyellow}>>> c_substitutions_eclm${cnormal}"
+route "${cyellow}<<< c_substitutions_eclm${cnormal}"
 }
 
 c_setup_eclm(){
-  route "${cyellow}>>> c_setup_clm${cnormal}"
-  route "${cyellow}<<< c_setup_clm${cnormal}"
+  route "${cyellow}>>> c_setup_eclm${cnormal}"
+  route "${cyellow}<<< c_setup_eclm${cnormal}"
 }
 
 ############################ 

--- a/bldsva/intf_oas3/common_build_interface.ksh
+++ b/bldsva/intf_oas3/common_build_interface.ksh
@@ -772,11 +772,35 @@ route "${cyellow}<<< c_setup_clm${cnormal}"
 
 c_configure_eclm(){
 route "${cyellow}>>> c_configure_clm${cnormal}"
+  comment "    Using land component model eCLM (experimental) \n"
+  comment "    Checking if eCLM repo is valid..."
+  cd ${clmdir}
+  git status >> $log_file 2>> $err_file
+  check
+  comment "    Running CMake configure step..."
+  ECLM_BUILD_DIR=${clmdir}/build >> $log_file 2>> $err_file
+  timer_start=$(date +%s)
+  cmake -S src -B "${ECLM_BUILD_DIR}" \
+      -DCMAKE_INSTALL_PREFIX="$bindir" \
+      -DCMAKE_C_COMPILER=mpicc \
+      -DCMAKE_Fortran_COMPILER=mpifort >> $log_file 2>> $err_file
+  check
+  timer_end=$(date +%s)
+  comment "    Configure step took $(date -u -d "0 $timer_end sec - $timer_start sec" +"%S") seconds\n"
 route "${cyellow}<<< c_configure_clm${cnormal}"
 }
 
 c_make_eclm(){
   route "${cyellow}>>> c_make_clm${cnormal}"
+  comment "    Building eCLM..."
+  timer_start=$(date +%s)
+  cmake --build "$ECLM_BUILD_DIR" >> $log_file 2>> $err_file
+  check
+  timer_end=$(date +%s)
+  comment "    Build succeeded! Build duration: $(date -u -d "0 $timer_end sec - $timer_start sec" +"%H:%M:%S")\n"
+  comment "    Installing eCLM..."
+  cmake --install "$ECLM_BUILD_DIR" >> $log_file 2>> $err_file
+  check
   route "${cyellow}<<< c_make_clm${cnormal}"
 }
 

--- a/bldsva/intf_oas3/common_build_interface.ksh
+++ b/bldsva/intf_oas3/common_build_interface.ksh
@@ -814,6 +814,9 @@ route "${cyellow}>>> c_make_eclm${cnormal}"
   comment "    Installing eCLM"
   cmake --install "$ECLM_BUILD_DIR" >> $log_file 2>> $err_file
   check
+  comment "    Installing clm5nl-gen"
+  pip3 install --user $clmdir/namelist_generator >> $log_file 2>> $err_file
+  check
 route "${cyellow}<<< c_make_eclm${cnormal}"
 }
 

--- a/bldsva/intf_oas3/common_build_interface.ksh
+++ b/bldsva/intf_oas3/common_build_interface.ksh
@@ -765,6 +765,30 @@ fi
 route "${cyellow}<<< c_setup_clm${cnormal}"
 }
 
+############################ 
+# eCLM interface methods
+############################
+
+
+c_configure_eclm(){
+route "${cyellow}>>> c_configure_clm${cnormal}"
+route "${cyellow}<<< c_configure_clm${cnormal}"
+}
+
+c_make_eclm(){
+  route "${cyellow}>>> c_make_clm${cnormal}"
+  route "${cyellow}<<< c_make_clm${cnormal}"
+}
+
+c_substitutions_clm(){
+route "${cyellow}>>> c_substitutions_clm${cnormal}"
+route "${cyellow}<<< c_substitutions_clm${cnormal}"
+}
+
+c_setup_eclm(){
+  route "${cyellow}>>> c_setup_clm${cnormal}"
+  route "${cyellow}<<< c_setup_clm${cnormal}"
+}
 
 ############################ 
 #Parflow interface methods

--- a/bldsva/intf_oas3/eclm/arch/JURECA/build_interface_eclm_JURECA.ksh
+++ b/bldsva/intf_oas3/eclm/arch/JURECA/build_interface_eclm_JURECA.ksh
@@ -1,0 +1,29 @@
+#!/bin/ksh
+
+always_clm(){
+route "${cyellow}>> always_clm${cnormal}"
+route "${cyellow}<< always_clm${cnormal}"
+}
+
+configure_clm(){
+route "${cyellow}>> configure_clm${cnormal}"
+    c_configure_eclm
+route "${cyellow}<< configure_clm${cnormal}"
+}
+
+make_clm(){
+route "${cyellow}>> make_clm${cnormal}"
+    c_make_eclm
+route "${cyellow}<< make_clm${cnormal}"
+}
+
+substitutions_clm(){
+route "${cyellow}>> substitutions_clm${cnormal}"
+route "${cyellow}<< substitutions_clm${cnormal}"
+}
+
+setup_clm(){
+route "${cyellow}>> setupClm${cnormal}"
+    c_setup_eclm
+route "${cyellow}<< setupClm${cnormal}"
+}

--- a/bldsva/intf_oas3/eclm/arch/JURECA/build_interface_eclm_JURECA.ksh
+++ b/bldsva/intf_oas3/eclm/arch/JURECA/build_interface_eclm_JURECA.ksh
@@ -7,7 +7,15 @@ route "${cyellow}<< always_clm${cnormal}"
 
 configure_clm(){
 route "${cyellow}>> configure_clm${cnormal}"
-    c_configure_eclm
+  #
+  # Uncomment these lines to customize build options.
+  #
+  # ECLM_CC=/path/to/mpicc
+  # ECLM_FC=/path/to/mpifort
+  # ECLM_CMAKE_VARS+=" -DBUILD_VAR1=VALUE1"
+  # ECLM_CMAKE_VARS+=" -DBUILD_VAR2=VALUE2"
+  #
+  c_configure_eclm
 route "${cyellow}<< configure_clm${cnormal}"
 }
 

--- a/bldsva/intf_oas3/eclm/arch/JUSUF/build_interface_eclm_JUSUF.ksh
+++ b/bldsva/intf_oas3/eclm/arch/JUSUF/build_interface_eclm_JUSUF.ksh
@@ -1,0 +1,29 @@
+#!/bin/ksh
+
+always_clm(){
+route "${cyellow}>> always_clm${cnormal}"
+route "${cyellow}<< always_clm${cnormal}"
+}
+
+configure_clm(){
+route "${cyellow}>> configure_clm${cnormal}"
+    c_configure_eclm
+route "${cyellow}<< configure_clm${cnormal}"
+}
+
+make_clm(){
+route "${cyellow}>> make_clm${cnormal}"
+    c_make_eclm
+route "${cyellow}<< make_clm${cnormal}"
+}
+
+substitutions_clm(){
+route "${cyellow}>> substitutions_clm${cnormal}"
+route "${cyellow}<< substitutions_clm${cnormal}"
+}
+
+setup_clm(){
+route "${cyellow}>> setupClm${cnormal}"
+    c_setup_eclm
+route "${cyellow}<< setupClm${cnormal}"
+}

--- a/bldsva/intf_oas3/eclm/arch/JUSUF/build_interface_eclm_JUSUF.ksh
+++ b/bldsva/intf_oas3/eclm/arch/JUSUF/build_interface_eclm_JUSUF.ksh
@@ -7,7 +7,15 @@ route "${cyellow}<< always_clm${cnormal}"
 
 configure_clm(){
 route "${cyellow}>> configure_clm${cnormal}"
-    c_configure_eclm
+  #
+  # Uncomment these lines to customize build options.
+  #
+  # ECLM_CC=/path/to/mpicc
+  # ECLM_FC=/path/to/mpifort
+  # ECLM_CMAKE_VARS+=" -DBUILD_VAR1=VALUE1"
+  # ECLM_CMAKE_VARS+=" -DBUILD_VAR2=VALUE2"
+  #
+  c_configure_eclm
 route "${cyellow}<< configure_clm${cnormal}"
 }
 

--- a/bldsva/intf_oas3/eclm/arch/JUWELS/build_interface_eclm_JUWELS.ksh
+++ b/bldsva/intf_oas3/eclm/arch/JUWELS/build_interface_eclm_JUWELS.ksh
@@ -1,0 +1,29 @@
+#!/bin/ksh
+
+always_clm(){
+route "${cyellow}>> always_clm${cnormal}"
+route "${cyellow}<< always_clm${cnormal}"
+}
+
+configure_clm(){
+route "${cyellow}>> configure_clm${cnormal}"
+    c_configure_eclm
+route "${cyellow}<< configure_clm${cnormal}"
+}
+
+make_clm(){
+route "${cyellow}>> make_clm${cnormal}"
+    c_make_eclm
+route "${cyellow}<< make_clm${cnormal}"
+}
+
+substitutions_clm(){
+route "${cyellow}>> substitutions_clm${cnormal}"
+route "${cyellow}<< substitutions_clm${cnormal}"
+}
+
+setup_clm(){
+route "${cyellow}>> setupClm${cnormal}"
+    c_setup_eclm
+route "${cyellow}<< setupClm${cnormal}"
+}

--- a/bldsva/intf_oas3/eclm/arch/JUWELS/build_interface_eclm_JUWELS.ksh
+++ b/bldsva/intf_oas3/eclm/arch/JUWELS/build_interface_eclm_JUWELS.ksh
@@ -7,13 +7,21 @@ route "${cyellow}<< always_clm${cnormal}"
 
 configure_clm(){
 route "${cyellow}>> configure_clm${cnormal}"
-    c_configure_eclm
+  #
+  # Uncomment these lines to customize build options.
+  #
+  # ECLM_CC=/path/to/mpicc
+  # ECLM_FC=/path/to/mpifort
+  # ECLM_CMAKE_VARS+=" -DBUILD_VAR1=VALUE1"
+  # ECLM_CMAKE_VARS+=" -DBUILD_VAR2=VALUE2"
+  #
+  c_configure_eclm
 route "${cyellow}<< configure_clm${cnormal}"
 }
 
 make_clm(){
 route "${cyellow}>> make_clm${cnormal}"
-    c_make_eclm
+  c_make_eclm
 route "${cyellow}<< make_clm${cnormal}"
 }
 
@@ -24,6 +32,6 @@ route "${cyellow}<< substitutions_clm${cnormal}"
 
 setup_clm(){
 route "${cyellow}>> setupClm${cnormal}"
-    c_setup_eclm
+  c_setup_eclm
 route "${cyellow}<< setupClm${cnormal}"
 }

--- a/bldsva/setup_tsmp.ksh
+++ b/bldsva/setup_tsmp.ksh
@@ -893,7 +893,11 @@ check
     comment "  source clm build interface for $platform"
       . ${rootdir}/bldsva/intf_oas3/${mList[1]}/arch/${platform}/build_interface_${mList[1]}_${platform}.ksh  >> $log_file 2>> $err_file
     check
-    if [[ $withPDAF == "false" ]] ; then
+    if [[ ${mList[1]} == "eclm" ]] ; then
+        comment "   Creating symlink to eclm.exe"
+        ln -s $bindir/bin/eclm.exe $rundir/eclm.exe >> $log_file 2>> $err_file
+        check
+    elif [[ $withPDAF == "false" ]] ; then
       comment "  cp clm exe to $rundir" 
         cp $bindir/clm $rundir >> $log_file 2>> $err_file
       check

--- a/bldsva/supported_versions.ksh
+++ b/bldsva/supported_versions.ksh
@@ -25,11 +25,11 @@ platforms+=(
 # IMPORTANT: add a leading and trailing " "(space)
 availability+=(
         ["JURECA"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF \
-                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF "
+                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT"
         ["JUWELS"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 
-                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF "
+                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT"
         ["JUSUF"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 
-                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF "
+                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT"
         ["MISTRAL"]=" 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 4.0.0MCT 4.1.0MCT 3.0.0MCTPDAF "
         ["AGROCLUSTER"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 3.0.0MCTPDAF "
         ["CCA2"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT "
@@ -55,6 +55,8 @@ versions+=(
         ["3.1.0MCT"]="3.1.0 old clm3_5 but new cosmo5_1 and Parflow3_7 and with Oasis3-MCT"
 	["1.4.0MCT"]="4.0.0 old clm3_5 and Parflow but new icon-lem with Oasis3-MCT"
 	["1.4.1MCT"]="4.0.0 old clm3_5 but new icon-lem and Parflow3_2 with Oasis3-MCT"
+        ["5.0.0"]="eCLM without modifications"
+        ["5.0.0MCT"]="eCLM with Oasis3-MCT"
 )
 
 
@@ -78,6 +80,8 @@ modelVersion+=(
         ["3.1.0"]="oasis3 clm3_5 cosmo5_1 parflow3_2"
 	["1.4.0MCT"]="oasis3-mct clm3_5-icon icon-lem parflow"
 	["1.4.1MCT"]="oasis3-mct clm3_5-icon icon-lem parflow3_2"
+        ["5.0.0"]="oasis3-mct eclm"
+        ["5.0.0MCT"]="oasis3-mct eclm"
 )
 
 # list of model combinations that are available for a version. (first is default) 
@@ -101,6 +105,8 @@ combinations+=(
         ["3.1.0"]=" clm-cos-pfl clm cos pfl clm-cos clm-pfl "
 	["1.4.0MCT"]=" clm-icon-pfl clm icon pfl clm-icon clm-pfl "
 	["1.4.1MCT"]=" clm-icon-pfl clm icon pfl clm-icon clm-pfl "
+        ["5.0.0"]=" clm "
+        ["5.0.0MCT"]=" clm "
 )
 
 #list of supported testcases for a certain machine.

--- a/bldsva/supported_versions.ksh
+++ b/bldsva/supported_versions.ksh
@@ -25,11 +25,11 @@ platforms+=(
 # IMPORTANT: add a leading and trailing " "(space)
 availability+=(
         ["JURECA"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF \
-                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT"
+                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT "
         ["JUWELS"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 
-                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT"
+                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT "
         ["JUSUF"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 
-                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT"
+                     1.4.0MCT 1.4.1MCT 3.0.0MCTPDAF 5.0.0 5.0.0MCT "
         ["MISTRAL"]=" 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 4.0.0MCT 4.1.0MCT 3.0.0MCTPDAF "
         ["AGROCLUSTER"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT 1.1.0MCTPDAF 3.0.0MCTPDAF "
         ["CCA2"]=" 1.1.0 1.1.0MCT 1.2.0 1.2.0MCT 2.1.0 2.1.0MCT 2.0.5 2.0.5MCT 3.0.0 3.0.0MCT 3.1.0 3.1.0MCT "
@@ -80,7 +80,7 @@ modelVersion+=(
         ["3.1.0"]="oasis3 clm3_5 cosmo5_1 parflow3_2"
 	["1.4.0MCT"]="oasis3-mct clm3_5-icon icon-lem parflow"
 	["1.4.1MCT"]="oasis3-mct clm3_5-icon icon-lem parflow3_2"
-        ["5.0.0"]="oasis3-mct eclm"
+        ["5.0.0"]="mct eclm"
         ["5.0.0MCT"]="oasis3-mct eclm"
 )
 

--- a/bldsva/supported_versions.ksh
+++ b/bldsva/supported_versions.ksh
@@ -125,12 +125,13 @@ setups+=(
         ["bonnRadar"]="two moment microphysics"
         ["bonn"]="flood area of interest"
 	["icon-ccs"]="icon non-hydrostatic convective boundary layer (Anurag et al. 2015)"
+        ["wtb1pt"]="1x1 Wuestebach"
 )
 
 # list of setups that are available on a machine. (first is default)
 # IMPORTANT: add a leading and trailing " "(space)
 setupsAvail+=(
-	["JUWELS"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex idealRTD multi-scale rur icon-ccs bonnRadar bonn seabreeze smresponse scalingStudy "
+	["JUWELS"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex idealRTD multi-scale rur icon-ccs bonnRadar bonn seabreeze smresponse scalingStudy wtb1pt "
         ["JUSUF"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex idealRTD multi-scale rur icon-ccs bonnRadar bonn seabreeze smresponse scalingStudy "
 	["JURECA"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex idealRTD multi-scale rur icon-ccs bonnRadar bonn seabreeze smresponse "
         ["MISTRAL"]=" nrw cordex idealRTD  "


### PR DESCRIPTION
I've temporarily assigned versions `5.0.0MCT` and `5.0.0` for eCLM. We'll discuss later in the meeting which proper version names to use. I've also added the test case `wtb1pt`. 

```sh
./build_tsmp.ksh -v 5.0.0MCT -c clm -m JUWELS -O Intel
./setup_tsmp.ksh -v 5.0.0MCT -V wtb1pt -m JUWELS -I _wtb -O Intel

# or 

./build_tsmp.ksh -v 5.0.0 -c clm -m JUWELS -O Intel
./setup_tsmp.ksh -v 5.0.0 -V wtb1pt -m JUWELS -I _wtb -O Intel
```