### PR TITLE
BUGFIX is64 - building ParFlow standalone

### DIFF
--- a/bldsva/intf_oas3/parflow3_7/arch/JURECA/build_interface_parflow3_7_JURECA.ksh
+++ b/bldsva/intf_oas3/parflow3_7/arch/JURECA/build_interface_parflow3_7_JURECA.ksh
@@ -14,7 +14,11 @@ route "${cblue}>> configure_pfl${cnormal}"
 #
     C_FLAGS="-fopenmp -Wall -Werror"
     flagsSim="  -DMPIEXEC_EXECUTABLE=$(which srun)"
-    flagsSim+=" -DPARFLOW_AMPS_LAYER=oas3"
+    if [[ $withOAS == "true" ]]; then
+        flagsSim+=" -DPARFLOW_AMPS_LAYER=oas3"
+    else
+        flagsSim+=" -DPARFLOW_AMPS_LAYER=mpi1"
+    fi
     flagsSim+=" -DOAS3_ROOT=$oasdir/$platform"
     flagsSim+=" -DSILO_ROOT=$EBROOTSILO"
     flagsSim+=" -DHYPRE_ROOT=$EBROOTHYPRE"

--- a/bldsva/intf_oas3/parflow3_7/arch/JUWELS/build_interface_parflow3_7_JUWELS.ksh
+++ b/bldsva/intf_oas3/parflow3_7/arch/JUWELS/build_interface_parflow3_7_JUWELS.ksh
@@ -14,7 +14,11 @@ route "${cblue}>> configure_pfl${cnormal}"
 #
     C_FLAGS="-fopenmp -Wall -Werror"
     flagsSim="  -DMPIEXEC_EXECUTABLE=$(which srun)"
-    flagsSim+=" -DPARFLOW_AMPS_LAYER=oas3"
+    if [[ $withOAS == "true" ]]; then
+        flagsSim+=" -DPARFLOW_AMPS_LAYER=oas3"
+    else
+        flagsSim+=" -DPARFLOW_AMPS_LAYER=mpi1"
+    fi
     flagsSim+=" -DOAS3_ROOT=$oasdir/$platform"
     flagsSim+=" -DSILO_ROOT=$EBROOTSILO"
     flagsSim+=" -DHYPRE_ROOT=$EBROOTHYPRE"


### PR DESCRIPTION
The build-interface is using hard-coded DPARFLOW_AMPS_LAYER=oas3,
which is not working without OASIS, as needed in standalone mode.
Adding a if-clause with fall-back of DPARFLOW_AMPS_LAYER=mpi1 in
case of OASIS is not compiled to fix this.

This fix is applied and tested for JUWELS and JURECA only. 