### PR TITLE
wrapper_tsmp, initialize_tsmp: remove unused variables

### DIFF
--- a/bldsva/intf_DA/pdaf1_1/model/wrapper_tsmp.c
+++ b/bldsva/intf_DA/pdaf1_1/model/wrapper_tsmp.c
@@ -31,12 +31,8 @@ wrapper_tsmp.c: Wrapper functions for TerrSysMP
 
 void initialize_tsmp() {
   int rank,size;
-  int subrank,subsize;
-  int coupcol,coupkey;
-  int interpfcol,interpfkey;
-  int tcycle;
-  int *pfrank;
-  int i,j;
+  int subrank;
+  int coupcol;
   int argc = 0; char ** argv ;
 
 


### PR DESCRIPTION
#114 

Unused variables removed - needs to be tested with FallSchoolCase before merge.