### PR TITLE
Send / receive zero values for uncoupled pixel

### DIFF
--- a/bldsva/intf_oas3/clm3_5/mct/oas_clm_snd.F90
+++ b/bldsva/intf_oas3/clm3_5/mct/oas_clm_snd.F90
@@ -79,11 +79,7 @@ allocate(buffer_array(begg:(begg+total_part_len-1)))
 
 ani = adomain%ni
 anj = adomain%nj
-! START NWR 2022-06-21                                                         
-! Set zeros values at 'not coupled pixels' as it seems to be intended originally
-!buffer_array = -999999._r8                                                    
 buffer_array = 0._r8                                                           
-! END NWR 2022-06-21
 last_owner=-1
 cl=0
 c=0

--- a/bldsva/intf_oas3/clm3_5/mct/oas_clm_snd.F90
+++ b/bldsva/intf_oas3/clm3_5/mct/oas_clm_snd.F90
@@ -79,7 +79,11 @@ allocate(buffer_array(begg:(begg+total_part_len-1)))
 
 ani = adomain%ni
 anj = adomain%nj
-buffer_array = -999999._r8
+! START NWR 2022-06-21                                                         
+! Set zeros values at 'not coupled pixels' as it seems to be intended originally
+!buffer_array = -999999._r8                                                    
+buffer_array = 0._r8                                                           
+! END NWR 2022-06-21
 last_owner=-1
 cl=0
 c=0

--- a/bldsva/intf_oas3/clm3_5/mct/send_fld_2pfl.F90
+++ b/bldsva/intf_oas3/clm3_5/mct/send_fld_2pfl.F90
@@ -112,7 +112,11 @@ ALLOCATE ( fsnd(begg:endg), stat=nerror)
    isec = dtime * ( get_nstep() -1 )
 
    DO jn = 1, vsnd
-     fsnd = -999999._r8
+     ! START NWR 2022-06-21
+     ! Set zeros values at 'not coupled pixels' as it seems to be intended originally
+     !fsnd = -999999._r8
+     fsnd = 0._r8
+     ! END NWR 2022-06-21
      DO g1 = begg, endg
         fsnd(g1) = pfl_flx_total_gcell(g1,jn)*3.6_r8/dz(g1,jn)
      END DO

--- a/bldsva/intf_oas3/clm3_5/mct/send_fld_2pfl.F90
+++ b/bldsva/intf_oas3/clm3_5/mct/send_fld_2pfl.F90
@@ -112,11 +112,7 @@ ALLOCATE ( fsnd(begg:endg), stat=nerror)
    isec = dtime * ( get_nstep() -1 )
 
    DO jn = 1, vsnd
-     ! START NWR 2022-06-21
-     ! Set zeros values at 'not coupled pixels' as it seems to be intended originally
-     !fsnd = -999999._r8
      fsnd = 0._r8
-     ! END NWR 2022-06-21
      DO g1 = begg, endg
         fsnd(g1) = pfl_flx_total_gcell(g1,jn)*3.6_r8/dz(g1,jn)
      END DO

--- a/bldsva/intf_oas3/clm3_5/oas3/send_fld_2pfl.F90
+++ b/bldsva/intf_oas3/clm3_5/oas3/send_fld_2pfl.F90
@@ -164,7 +164,10 @@ ALLOCATE ( fsnd(ndlon,ndlat,nlevsoi), stat=nerror)
 
 ! zero on unmasked points
    fsnd = 0._r8
-   fsnd = -999999._r8
+   ! START NWR 2022-06-21
+   ! I want zeros at 'not coupled pixels' as it seems to be intended originally
+   !fsnd = -999999._r8
+   ! END NWR 2022-06-21
 
    DO jn = 1, vsnd
    DO g1 = 1, numg

--- a/bldsva/intf_oas3/clm3_5/oas3/send_fld_2pfl.F90
+++ b/bldsva/intf_oas3/clm3_5/oas3/send_fld_2pfl.F90
@@ -164,10 +164,6 @@ ALLOCATE ( fsnd(ndlon,ndlat,nlevsoi), stat=nerror)
 
 ! zero on unmasked points
    fsnd = 0._r8
-   ! START NWR 2022-06-21
-   ! I want zeros at 'not coupled pixels' as it seems to be intended originally
-   !fsnd = -999999._r8
-   ! END NWR 2022-06-21
 
    DO jn = 1, vsnd
    DO g1 = 1, numg


### PR DESCRIPTION
- force CLM to send zero values for uncoupled pixel, as missing values like 9999 could crash other components if they receive those.
- force ParFlow to receive zero values for uncoupled pixel, as missing values like 9999 could crash ParFlow, if they are treated as valid forcing.