### PR TITLE
Enable maxpft>1

### DIFF
--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -32,6 +32,7 @@ getDefaults(){
   def_mode="0" #0: let flags decide, 1:batch, 2:interactive
   def_cplscheme="true"
   def_readCLM="false"
+  def_maxpft="1"
   def_freeDrain="false"
 
   #compiler optimization
@@ -94,6 +95,7 @@ setDefaults(){
 
   freeDrain=$def_freeDrain
   readCLM=$def_readCLM
+  maxpft=${def_maxpft}
   cplscheme=$def_cplscheme
   mode=$def_mode
 
@@ -563,9 +565,10 @@ printState(){
   print "${cred}(25)${cnormal} profiling (default=$def_profiling): ${cgreen}$profiling ${cnormal}"
   print "${cred}(26)${cnormal} Couple-Scheme (default=$def_cplscheme): ${cgreen}$cplscheme ${cnormal}"
   print "${cred}(27)${cnormal} readCLM: Consistently read CLM-mask (default=$def_readCLM): ${cgreen}$readCLM ${cnormal}"
-  print "${cred}(28)${cnormal} Compiles ParFlow with free drainage feature (default=$def_freeDrain): ${cgreen}$freeDrain ${cnormal}"
-  print "${cred}(29)${cnormal} compiler (default=$defaultcompiler): ${cgreen}$compiler ${cnormal}"
-  print "${cred}(30)${cnormal} processor (default=$defaultprocessor): ${cgreen}$processor ${cnormal}"
+  print "${cred}(28)${cnormal} maxpft: Set maxpft per grid cell for CLM (default=$def_maxpft): ${cgreen}$maxpft ${cnormal}"
+  print "${cred}(29)${cnormal} Compiles ParFlow with free drainage feature (default=$def_freeDrain): ${cgreen}$freeDrain ${cnormal}"
+  print "${cred}(30)${cnormal} compiler (default=$defaultcompiler): ${cgreen}$compiler ${cnormal}"
+  print "${cred}(31)${cnormal} processor (default=$defaultprocessor): ${cgreen}$processor ${cnormal}"
 }
 
 check(){
@@ -863,6 +866,7 @@ getGitInfo(){
   USAGE+="[c:combination? Combination of component models.]:[combination:='$def_combination']"
   USAGE+="[C:cplscheme? Couple-Scheme for CLM/COS coupling.]:[cplscheme:='$def_cplscheme']"
   USAGE+="[r:readclm? Flag to consistently read in CLM mask.]:[readclm:='$def_readCLM']"
+  USAGE+="[f:maxpft? Flag to control maxpft per grid cell in CLM.]:[maxpft:='$def_maxpft']"
   USAGE+="[d:freedrain? Compiles ParFlow with free drainage feature.]:[freedrain:='$def_freeDrain']"
 
   USAGE+="[W:optoas?Build option for Oasis.]:[optoas:='${def_options["oas"]}']{"
@@ -916,6 +920,7 @@ getGitInfo(){
     c)  combination="$OPTARG" ; args=1 ;;
     C)  cplscheme="$OPTARG" ; args=1 ;;
     r)  readCLM="$OPTARG" ; args=1 ;;
+    f)  maxpft="$OPTARG" ; args=1 ;;
     d)  freeDrain="$OPTARG" ; args=1 ;;
 #DA
     T)  options+=(["icon"]="$OPTARG") ; args=1 ;;
@@ -942,8 +947,6 @@ getGitInfo(){
     A)  processor="$OPTARG" ; args=1 ;;
     esac
   done
-
-
 
 
 comment "  source list with supported machines and configurations"

--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -32,7 +32,7 @@ getDefaults(){
   def_mode="0" #0: let flags decide, 1:batch, 2:interactive
   def_cplscheme="true"
   def_readCLM="false"
-  def_maxpft="1"
+  def_maxpft="1" # (CLM default is 4)
   def_freeDrain="false"
 
   #compiler optimization

--- a/bldsva/intf_oas3/clm3_5/tsmp/Biogeophysics1Mod.F90
+++ b/bldsva/intf_oas3/clm3_5/tsmp/Biogeophysics1Mod.F90
@@ -418,7 +418,7 @@ contains
 ! to correct the forc_hgt. This way we do not run into above error. 
 ! However, keep in mind that this correction is still a workaround.
 tmp_displacement = 0._r8 ! scalar
-tmp_displacement_max = 0._r8 ! same shape as forc_hgt
+tmp_displacement_max(:) = 0._r8 ! same shape as forc_hgt
 !
 ! First calculate max displacement for all columns and pfts on grid lvl
     ! max_pft_per_col = im code festgelegte max moeglicher pft (17)

--- a/bldsva/intf_oas3/clm3_5/tsmp/Biogeophysics1Mod.F90
+++ b/bldsva/intf_oas3/clm3_5/tsmp/Biogeophysics1Mod.F90
@@ -183,7 +183,6 @@ contains
     real(r8) :: psit    !negative potential of soil
     real(r8) :: hr      !relative humidity
     real(r8) :: wx      !partial volume of ice and water of surface layer
-!NWa
 !NOTE: Arrays can start from arbitrary index... 
 !      So in CLM the distributed arraies (over diff. CPUs) does take the index
 !      from the original array.
@@ -191,7 +190,6 @@ contains
 !      The Uper and lower index bound is stored in `lbg`, `ubg`, etc.
     real(r8) :: tmp_displacement_max(lbg:ubg)  !helper var 
     real(r8) :: tmp_displacement               !helper var 
-!NWa
 !------------------------------------------------------------------------------
 
    ! Assign local pointers to derived type members (gridcell-level)
@@ -408,7 +406,7 @@ contains
 
     end do
 
-! NWa change forc_hgt = forc_hgt + z0m + displa at PFT level
+! Change forc_hgt = forc_hgt + z0m + displa at PFT level
 ! forc_hgt is send from COSMO to CLM via fix value. In fully coupled mode, this
 ! fix value can conflict with the actual canopy height, showing up as CLM error
 ! with the message:
@@ -419,7 +417,6 @@ contains
 ! calculated for each pft present, and second the maximum displacement is taken 
 ! to correct the forc_hgt. This way we do not run into above error. 
 ! However, keep in mind that this correction is still a workaround.
-! NWa Do not forget to allocate below variables
 tmp_displacement = 0._r8 ! scalar
 tmp_displacement_max = 0._r8 ! same shape as forc_hgt
 !
@@ -462,11 +459,9 @@ tmp_displacement_max = 0._r8 ! same shape as forc_hgt
       
       ! Update forc_hgt on grid lvl
       forc_hgt_u(g) = forc_hgt_u(g) + tmp_displacement_max(g)
-      !write(6,*)'DEBUG: forc_hgt_u(g)', forc_hgt_u(g)
       forc_hgt_t(g) = forc_hgt_t(g) + tmp_displacement_max(g)
       forc_hgt_q(g) = forc_hgt_q(g) + tmp_displacement_max(g)
     end do
-!! NWR
 
   end subroutine Biogeophysics1
 

--- a/bldsva/intf_oas3/clm3_5/tsmp/Biogeophysics1Mod.F90
+++ b/bldsva/intf_oas3/clm3_5/tsmp/Biogeophysics1Mod.F90
@@ -426,7 +426,6 @@ tmp_displacement_max(:) = 0._r8 ! same shape as forc_hgt
       ! num_nolakec: number of column non-lake points in column filter
       do fc = 1,num_nolakec
         c = filter_nolakec(fc)
-        l = clandunit(c)
         g = cgridcell(c)
         if (pi <= npfts(c)) then
           p = pfti(c) + pi - 1

--- a/bldsva/intf_oas3/common_build_interface.ksh
+++ b/bldsva/intf_oas3/common_build_interface.ksh
@@ -633,7 +633,10 @@ route "${cyellow}>>> c_configure_clm${cnormal}"
     cp $rootdir/bldsva/intf_oas3/${mList[1]}/oas3/oas_clm_init.F90 $clmdir/src/oas3
 
     spmd="on"       # settings are [on   | off       ] (default is off)
-    maxpft="1"        # settings are 4->17               (default is 4)
+    # NWa 20230214
+    # Test maxpft>1
+    maxpft="4"        # settings are 4->17               (default is 4)
+    #maxpft="1"        # settings are 4->17               (default is 4)
     rtm="off"      # settings are [on   | off       ] (default is off) 
     cps_catch="off"       # settings are [on   | off       ] (default is off)
     usr_src="$clmdir/bld/usr.src "

--- a/bldsva/intf_oas3/common_build_interface.ksh
+++ b/bldsva/intf_oas3/common_build_interface.ksh
@@ -633,10 +633,6 @@ route "${cyellow}>>> c_configure_clm${cnormal}"
     cp $rootdir/bldsva/intf_oas3/${mList[1]}/oas3/oas_clm_init.F90 $clmdir/src/oas3
 
     spmd="on"       # settings are [on   | off       ] (default is off)
-    # NWa 20230214
-    # Test maxpft>1
-    maxpft="4"        # settings are 4->17               (default is 4)
-    #maxpft="1"        # settings are 4->17               (default is 4)
     rtm="off"      # settings are [on   | off       ] (default is off) 
     cps_catch="off"       # settings are [on   | off       ] (default is off)
     usr_src="$clmdir/bld/usr.src "


### PR DESCRIPTION
- set `maxpft=4` as new default in `bldsva/intf_oas3/common_build_interface.ksh`
- rewrite workaround in `bldsva/intf_oas3/common_build_interface.ksh` correcting `forc_hgt` according to pft types present in CLM35 grid cell. This is now working for `maxpft!=1` as well.