### PR TITLE
Migrate exisiting documentation from JSC GitLab

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           pip install sphinx-copybutton
       - name: Sphinx build
         run: |
-          sphinx-build doc _build
+          sphinx-build -a doc _build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
         run: |
           pip install --upgrade myst-parser
           pip install sphinx sphinx_rtd_theme
+          pip install sphinx-copybutton
       - name: Sphinx build
         run: |
           sphinx-build doc _build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: RenderSphinxDocumentation
-on: [pull_request, workflow_dispatch]
+on: [workflow_dispatch]
 jobs:
   makeDoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: RenderSphinxDocumentation
-on: [workflow_dispatch]
+on: [push, workflow_dispatch]
 jobs:
   makeDoc:
     runs-on: ubuntu-latest

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,8 +18,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'TSMP-Documentation'
-copyright = '2023, Niklas WAGNER'
-author = 'Niklas WAGNER'
+copyright = '2023'
+author = '- Prabhakar SHRESTHA, Wolfgang KURTZ, Fabian GASPER, Mukund PONDKULE, Johannes KELLER, Stefan POLL, Niklas WAGNER'
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,6 +28,12 @@ author = 'Niklas WAGNER'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+        'sphinx.ext.autodoc',
+        'sphinx.ext.viewcode',
+        'sphinx_rtd_theme',
+        'sphinx.ext.napoleon',
+        'sphinx.ext.mathjax',
+        'sphinx_copybutton',
         'myst_parser'
 ]
 

--- a/doc/content/best_practices.md
+++ b/doc/content/best_practices.md
@@ -1,0 +1,12 @@
+# Development Best Practices #
+
+
+## Repositories ##
+
+Development scheme:
+- Github: `TSMP` general development
+- Gitlab: `TSMP` is always kept up-to-date and changes are merged into
+  the `TSMP-PDAF`-related branches.
+  
+Every branch from Github should always have an identical clone on
+Gitlab!

--- a/doc/content/branches.md
+++ b/doc/content/branches.md
@@ -1,0 +1,29 @@
+# TSMP-PDAF related branches #
+
+
+## Main branches ##
+
+| Branch        | Information                           |
+|---------------|---------------------------------------|
+| `master`      | current main branch                   |
+| `TSMP_pdaf`   | current main TSMP-PDAF branch         |
+
+## Development branches ##
+
+| Branch                 | Information                                           |
+|------------------------|-------------------------------------------------------|
+| `pdaf_lenkf_fix`       | TSMP-PDAF developments by Ching                       |
+| `for2131-*`            | Developments from FOR2131                             |
+| `for2131-supermuc`     | @bschalge bash-scripts for SuperMUC plus developments |
+| `for2131-natascha`     | @nbrandhorst developments (cleaned up)                |
+| `for2131-natascha-dev` | @nbrandhorst developments without cleanup             |
+| `pdaf-cmem`            | @spoll and @lvshaoning                                |
+| `clm5-coupling`        | @lstrebel                                             |
+| `doc`                  | documentation by @tschruff                            |
+| `coupling-cos-pdaf`    |                                                       |
+| `agrocluster-dorina`   | @dbaatz, freezed out earlier version of TSMP          |
+| `couple_icon`          |                                                       |
+| `TSMP_pdaf-crns`       | Branch by @cphung for FOR2131                         |
+
+
+`*-pdaf`: Branches that are up-to-date with branch `TSMP_pdaf`.

--- a/doc/content/build_environment_variables.md
+++ b/doc/content/build_environment_variables.md
@@ -1,0 +1,55 @@
+## TSMP-PDAF Environment variables ##
+
+A number of environment variables are set during the build process of
+TSMP-PDAF in order to make the code behave in specific ways.
+
+TSMP-PDAF environemnt variables are set in the machine-specific
+TSMP-PDAF build-scripts of the form:
+
+```
+bldsva/intf_DA/pdaf1_1/arch/<machine>/build_interface_pdaf1_1_<machine>.ksh
+```
+
+where `<machine>` could be f.e. `JURECA` or `JUWELS`.
+
+### CLMSA ###
+
+Environment variable `CLMSA` is true if CLM-standalone is used in
+TSMP-PDAF, i.e. no coupling to other component models (ParFlow,
+atmospheric model).
+
+`CLMSA` is used in many places in TSMP-PDAF, where CLM-standalone
+specific code is introduced. This includes
+- observation reading
+- setting observation vector
+- setting state vector
+- communicator handling
+- localized filters
+- TSMP-PDAF-wrapper routines
+
+### PARFLOW_STAND_ALONE ###
+
+Environment variable `PARFLOW_STAND_ALONE` is true if
+ParFlow-standalone is used in TSMP-PDAF, i.e. no coupling to other
+component models (CLM, atmospheric model).
+
+It is used less frequently than [CLMSA](#clmsa), only at code places
+where the behavior of ParFlow-CLM-PDAF and ParFlow-PDAF should differ.
+
+### OBS_ONLY_PARFLOW ###
+
+Environment variable `OBS_ONLY_PARFLOW` is true if observations in
+TSMP-PDAF are of ParFlow-type.
+
+This will remove unnecessary code during observation reading, when
+ParFlow-CLM-PDAF is built, but no CLM-type observations are included.
+
+### OBS_ONLY_CLM ###
+
+Environment variable `OBS_ONLY_CLM` is true if observations in
+TSMP-PDAF are of CLM-type.
+
+This will remove unnecessary code during observation reading, when
+ParFlow-CLM-PDAF is built, but no ParFlow-type observations are
+included.
+

--- a/doc/content/build_examples.md
+++ b/doc/content/build_examples.md
@@ -1,0 +1,37 @@
+# Building TSMP #
+
+These are example builds of TSMP that are frequently tested.
+	
+**Build script of TSMP**
+
+To get information about TSMP build options for different version
+using standalone or different combination of model components on
+different machines inside the folder `TSMP/bldsva` execute
+
+``` bash
+	./build_tsmp.ksh -a
+```
+
+you can also use `--man` or `--help` to get terrsysmp build options
+
+``` bash
+	./build_tsmp.ksh --man ./build_tsmp.ksh --help
+```
+
+for building `TSMP` with COSMO-CLM3.5-ParFlow the following internal version is recommended:
+-   `3.1.0MCT` (recommended).
+
+for building `TSMP-PDAF` the following internal versions can be used:
+-   `1.1.0MCTPDAF`
+-   `3.0.0MCTPDAF`
+-   `3.1.0MCTPDAF` (recommended).
+
+```{toctree} 
+---
+maxdepth: 3
+caption: Build Examples for TSMP-PDAF
+---
+build_examples_tsmp.md
+build_examples_tsmppdaf.md
+build_environment_variables.md
+```

--- a/doc/content/build_examples_tsmp.md
+++ b/doc/content/build_examples_tsmp.md
@@ -1,0 +1,85 @@
+## TSMP Build Examples ##
+
+**Attention**: Not all of this examples were tested and paths are
+mostly made up.
+
+### Builds ###
+
+#### Fully coupled TSMP with Oasis3-MCT ####
+
+        ./build_tsmp.ksh -m JUWELS -c clm-cos-pfl -v 3.1.0MCT -O Intel
+        ./build_tsmp.ksh -m JURECA -c clm-cos-pfl -v 3.1.0MCT -O Intel
+
+`-O Intel`: Currently, on `JUWELS`, on stage `2020`, the compilation
+with Intel-Compiler is recommended. It can explicitly be called by the
+flag `-O Intel`.
+
+The `-c` and `-v` flag are optional in this case because they are
+default.
+
+    -   **TSMP**
+
+        -   revision `1b69ac4` on `master` Github repository `TSMP`
+
+    -   **clm3\_5**
+
+        -   Version 3.5, `clm3_5/Copyright`, `share3_070321` in
+            `clm3_5/src/csm_share/ChangeLog`
+
+        -   Gitlab repo
+            <https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/clm3.5_fresh.git>,
+            revision `801b5304`
+
+    -   **cosmo5\_1**
+
+        -   Gitlab repo
+            <https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/cosmo5.01_fresh.git>,
+            `f407b9b`
+
+    -   **oasis3-mct**
+
+        -   similar: svn revision r1506, `svn info` (caused error)
+
+        -   now: Gitlab repo
+            <https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/oasis3-mct.git>,
+            tag `svn-r1506`, revision `bc58342`)
+
+    -   **parflow3\_2**
+
+        -   Version v3.2.0 in `VERSION`
+
+        -   no `CMakeLists.txt` yet
+
+        -   NOW: repo
+            <https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/parflow3.2_legacy.git>,
+            revision `98a8701` Remark: This is the same repository as the official ParFlow 
+			repository on <https://github.com/parflow/parflow>
+
+    -   **NO pdaf1\_1**
+
+        -   Version 1.15.0 in `/pdaf1_1/src/PDAF-D_print_version.F90`,
+            new version
+
+#### Compile ParFlow standalone on CLUMA2 without compiler optimization ####
+
+      ./build_tsmp.ksh -m CLUMA2 -c pfl -v 1.1.0MCT -o "O0"
+
+The `-m` and `-v` flag are optional in this case because they are
+default.
+
+#### Compile new CLM4.0 + Cosmo5.1 on JURECA ####
+
+      ./build_tsmp.ksh -m JURECA -c clm-cos -v 2.1.0MCT -C false
+
+The new models are currently only supported for clm-cos and with
+alternative coupling-scheme.
+
+#### Compile standalone eCLM ####
+
+Branch `master`. Building eCLM. Currently, only standalone.
+
+``` bash
+	./build_tsmp.ksh -v 5.0.0 -c clm -m JURECA -O Intel
+	./build_tsmp.ksh -v 5.0.0MCT -c clm -m JURECA -O Intel	
+```
+

--- a/doc/content/build_examples_tsmppdaf.md
+++ b/doc/content/build_examples_tsmppdaf.md
@@ -1,0 +1,199 @@
+## TSMP-PDAF Build Examples ##
+
+A collection of build examples for TSMP-PDAF.
+
+All builds involving more than one coupled component model use the
+coupling software Oasis3-MCT.
+
+- [`Compile fully coupled TSMP-PDAF`](#compile-fully-coupled-tsmp-pdaf-on-jureca)
+- [`Compile ParFlow standalone with PDAF`](#compile-parflow-and-clm-with-pdaf)
+- [`Compile ParFlow and CLM with PDAF`](#compile-parflow-standalone-with-pdaf-on-juwels-without-compiler-optimization)
+
+### Compile fully coupled TSMP-PDAF (on JURECA) ###
+
+The first example runs the build script of TSMP-PDAF, specifies the
+machine `JURECA`, specifies the component models CLM, COSMO and
+ParFlow and specifies version `1.1.0MCTPDAF`.
+
+      ./build_tsmp.ksh -m JURECA -c clm-cos-pfl -v 1.1.0MCTPDAF
+
+The `-c` and `-v` flag are optional in this case because the inputs for
+these flags on `-m JURECA` are equivalent to the corresponding default
+inputs.
+
+The `-v` flag is optional in this case because `-c clm-cos-pfl` is the
+default input for this flag on `-m JURECA` and for version `-v
+1.1.0MCTPDAF`.
+
+By default the `build_tsmp.ksh` script will make a copy of the original
+model source folder (named as in the catalog, f.e. `clm3_5`,
+`cosmo4_21`, and `parflow`) and back it up to
+`MODEL_ARCH_VERSION_COMBINATION`.
+
+With the flags `-wxyz` (see man-page) you can specify your own directory
+where it is backed up to. If you like to use your own folder structure
+for the models you can again select your own model-path with `-wxyz` and
+avoid making a backup with `-WXYZ` option set to \"`build`\".
+
+### Compile Parflow and CLM with PDAF ###
+
+#### Build commands ####
+
+Build commands for different machines.
+
+Remarks:
+- For building TSMP-PDAF with DA, use branch `TSMP_pdaf`
+- Parflow-3.9 is supported using version tag `3.1.0MCTPDAF`. For older
+  versions, use `3.0.0MCTPDAF` (>=3.2, <3.7), `1.1.0MCTPDAF` (<3.2).
+
+##### JURECA #####
+
+      ./build_tsmp.ksh -m JURECA -c clm-pfl -v 3.1.0MCTPDAF -O Intel
+
+##### JUWELS #####
+
+      ./build_tsmp.ksh -m JUWELS -c clm-pfl -v 3.1.0MCTPDAF -O Intel
+
+##### Remote build #####
+
+``` shell
+	./build_tsmp_remote -m JUWELS -v 3.1.0MCTPDAF -O Intel -c clm-pfl -branch TSMP_pdaf -host juwels &
+	./build_tsmp_remote -m JURECA -v 3.1.0MCTPDAF -O Intel -c clm-pfl -branch TSMP_pdaf -host jureca &
+```
+
+#### Component Models ####
+
+The build commands were last tested for these component models
+
+- **TSMP**
+  - current revision of branch `TSMP_pdaf` from
+    <https://github.com/HPSCTerrSys/TSMP>
+
+- **clm3\_5**
+  - Version 3.5, `clm3_5/Copyright`, `share3_070321` in
+    `clm3_5/src/csm_share/ChangeLog`
+    <https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/clm3.5_fresh>
+    revision `801b5304179f0a8cbe3dc2c50b584a6bfee387b0`
+- **oasis3-mct**
+  - (svn revision r1506, `svn info` (caused error);
+  - new: Gitlab repo
+	<https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/oasis3-mct.git>,
+	branch `oasis3-MCT_2.0`, revision `bc58342`)
+- **parflow3\_0** (`1.0.0MCTPDAF`)
+  - Version v3.2.0 in `VERSION`, no `CMakeLists.txt` yet, revision
+    `faaee2c` in `parflow_vTdz` from
+    <https://git.meteo.uni-bonn.de/git/parflow>
+- **parflow3\_2** (`3.0.0MCTPDAF`)
+  - Version v3.2.0 in `VERSION`, no `CMakeLists.txt` yet, revision
+    `98a87011` in `master` from
+    <https://github.com/parflow/parflow.git>
+- **parflow** (`3.1.0MCTPDAF`)
+  - Version Tag `v3.9.0`, revision `bc80e3ac` from
+    <https://github.com/parflow/parflow.git>
+- **pdaf1\_1**
+  - Version 2.0 in `/pdaf1_1/src/PDAF_print_version.F90`, new version
+
+Not used:
+- **cosmo4\_21**
+  - Gitlab REPO
+    <https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/cosmo4.21_fresh.git>,
+    `c81de76`
+	- Makefile different to other **cosmo4\_21** versions
+
+### Compile ParFlow standalone with PDAF (on JUWELS without compiler optimization) ###
+
+      ./build_tsmp.ksh -m JUWELS -c pfl -v 1.1.0MCTPDAF -o -O0
+
+The `-c` and `-v` flag are optional in this case because the inputs
+for these flags on `-m JUWELS` are equivalent to the corresponding
+default inputs.
+
+      ./build_tsmp.ksh -m JUWELS -c pfl -v 1.1.0MCTPDAF -o -g
+
+The `-g` flag, is build to produce debugging information.
+
+### Compile CLM5 with PDAF ###
+
+CLM5-PDAF compilation, currently available only on branch
+`TSMP_pdaf-clm5` (January 2023).
+
+``` bash
+	./build_tsmp.ksh -v 4.4.0MCTPDAF -c clm -m JURECA -O Intel
+```
+
+#### Prerequisite1: CLM5 preparation ####
+
+For obtaining and preparing the component model `clm5_0`, you
+have to run the following commands
+
+``` bash
+	git clone git@github.com:ESCOMP/CTSM.git clm5_0
+	cd clm5_0
+	git checkout release-clm5.0
+	./manage_externals/checkout_externals
+```
+
+#### Prerequisite2: Path to cesm ####
+
+The path `CESMDATAROOT` needs to be changed in
+`TSMP/bldsva/intf_oas3/clm5_0/arch/JURECA/config/softwarepaths.ksh`. (analogous
+for `JUWELS`).
+
+Currently you need to have access to compute project `cjicg41` and use the line:
+```bash
+	export CESMDATAROOT=/p/scratch/cjicg41/<user>/cesm
+```
+For `<user>`, please contact someone on the inside.
+
+
+### Debug tips ###
+
+#### Debug Tip 1: Skip component models in TSMP-PDAF build ####
+
+``` shell
+./build_tsmp.ksh -m JURECA -c clm-cos-pfl -v 1.1.0MCTPDAF -W skip -X skip
+```
+
+Oasis and CLM compilation are skipped with the option `skip` for flags
+`-W` and `-X`. Parflow and pdaf are compiled after Cosmo.
+
+All flags can be found using `./build_tsmp.ksh --help`. Here, the
+output for flag of componeent model build options:
+``` shell
+	-W, --optoas=optoas
+                  Build option for Oasis.
+                    fresh        #build from scratch in a new folder
+                    build        #build clean
+                    make         #only (resume) make and make install - no make clean and configure
+                    configure    #only make clean and configure - no make
+                    skip         #no build
+                  The default value is 'fresh'.
+  -E, --opticon=opticon
+                  Build option for ICON. The default value is 'fresh'.
+  -Y, --optcos=optcos
+                  Build option for Cosmo. The default value is 'fresh'.
+  -X, --optclm=optclm
+                  Build option for CLM. The default value is 'fresh'.
+  -Z, --optpfl=optpfl
+                  Build option for Parflow. The default value is 'fresh'.
+  -U, --optda=optda
+                  Build option for Data Assimilation. The default value is 'fresh'.
+```
+
+#### Debug Tip 2: Building TSMP-PDAF after source code changes in component models ####
+
+``` shell
+./build_tsmp.ksh -m JURECA -c clm-cos-pfl -v 1.1.0MCTPDAF -W skip -X skip -Y make
+```
+
+Oasis and CLM compilation are skipped with the option `skip` for flags
+`-W` and `-X`.
+
+Cosmo compilation is resumed without making clean with option `make`
+for flag `-Y`. The source code change needs to be made in
+`cosmo4_21_JURECA_1.1.0MCTPDAF_clm-cos-pfl`. **But note**: The source
+code change will be lost after the next clean build of cosmo. Thus,
+make sure to incorporate the source code changes in the designated
+replace structures.
+
+	

--- a/doc/content/contributing/documentation.md
+++ b/doc/content/contributing/documentation.md
@@ -25,7 +25,7 @@ Building the documentation is done by moving to `doc/` and running the command
 Simply browse to this directory and open `index.html' which should show you the 
 locally rendered documentation in your default web browser.
 
-# Below part may be moved 
+## Below part may be moved 
 
 The automatic rendering of the documentation on GitHub is achived by [GitHub 
 actions](https://github.com/features/actions). On GitHub you can find it in the 

--- a/doc/content/debugging.md
+++ b/doc/content/debugging.md
@@ -1,0 +1,48 @@
+# Debugging TSMP #
+
+See also [Debug Tips](build_examples.md#debug-tips) for building
+TSMP!
+
+If an error appears and the source can not be localized by the default
+outputs, it might make sense to build TSMP-PDAF again, but with more
+debug-flags enabled.
+
+For `JUWELS` these flags can be set in
+
+- `bldsva/intf_DA/pdaf1_1/arch/JUWELS/build_interface_pdaf1_1_JUWELS.ksh`
+- `bldsva/machines/JUWELS/build_interface_JUWELS.ksh`
+
+
+In `build_interface_JUWELS.ksh`, there is `defaultOptC`, which can be
+set, f.e. as
+
+``` ksh
+defaultOptC="-g -O0 -xHost -traceback" # Intel
+```
+
+For TSMP-PDAF: In `build_interface_pdaf1_1_JUWELS.ksh`, there is the general
+`importFlags` that could for example be set as
+
+```ksh
+importFlags="-g -traceback"
+```
+
+Watch out here, to get the right condition (Intel / Fortran
+compilers)! The examples are for the Intel compiler, gcc-flags are
+slightly different.
+
+## Debugging with TotalView
+
+It is possible to debug TSMP with multiple coupled components with the mean of the TotalView debugger. 
+
+Please contact the SDLTS for support for the initial set up TotalView on JSC machines. 
+
+1) Start interactive session. E.g. on JUWELS machine 
+```sh
+salloc --partition=devel --nodes=5 --account=PROJECT --time=01:30:00
+```
+
+2) Setup and modifiy the submission script of TSMP
+```sh
+totalview -args srun --multi-prog slm_multiprog_mapping.conf
+```

--- a/doc/content/development.md
+++ b/doc/content/development.md
@@ -1,0 +1,47 @@
+# Developing TSMP #
+
+## Supporting a new machine ##
+
+First of all make sure that the new machine is introduced to the
+`supported_machines.ksh` script.
+
+Create the necessary folder structure under `intf_oas3` and create a
+script for this machine and every component-model that will be
+supported and implement the interface.
+
+If necessary add `src/config` folders if machine specific source-code or
+`config/make` files are needed.
+
+Add a folder with the machine name under `/machines`. Also add the
+machine-interface and implement the interface. Also add files to load
+modules if necessary.
+
+For both cases it is easiest to copy a similar machine and change names
+and specifics accordingly.
+
+## Setting up a new experiment ##
+
+First of all make sure that the new setup is introduced to the
+`supported_machines.ksh` script.
+
+Add a folder with the setup name under `/setups`.
+
+Also add the setup-interface for all machines that are supported and
+implement the interface.
+
+Also add namelists for all component-models.
+
+The namelist name must match to the according entry in the setup
+interface.
+
+namelists for `cosmo5.1` and `clm4.0` must have the version as suffix
+even if declared otherwise in the setup interface. For example
+`lmrun_uc5_1` and `lnd.stdin4_0`. But in the setup-interface it must
+be written `lmrun_uc` and `lnd.stdin`.
+
+Also for ensembles in TSMP-PDAF the ensemble namelists must then be named like
+`lmrun_uc5_1_4711` or `lnd.stdin4_0_4711` for ensemble member 4711 even
+if `lmrun_uc` and `lnd.stdin` is specified by the setup interface or
+flags. Again it is easiest to copy a similar setup and change names and
+specifics accordingly.
+

--- a/doc/content/gettingstarted.md
+++ b/doc/content/gettingstarted.md
@@ -1,4 +1,4 @@
-# Welcome to TSMP-Documentation
+# Getting Started
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At 

--- a/doc/content/input_clm.md
+++ b/doc/content/input_clm.md
@@ -1,0 +1,26 @@
+## Input files for CLM ##
+
+For executing TSMP-PDAF, the standard CLM input file `lnd.stdin` is
+replaced by separate input files for the individual CLM realisations.
+The naming convention for these input files is a user defined prefix
+followed by a formatted realisation number. For example, if the chosen
+prefix is `clminput`, the file names for the first three realisations
+are:
+
+```text
+clminput_00000
+clminput_00001
+clminput_00002
+```
+
+All these files follow the same structure as the standard CLM input
+file `lnd.stdin`. The timing information needs to be the same for all
+these CLM input files but all other variables representing CLM input
+and output can differ between the realisations. It is important to
+note that the variable `caseid` should be an individual identifier for
+each CLM realisation because this variable determines the names of the
+CLM output files. If certain realisation share the same `caseid` the
+name of the CLM output files will be the same for these realisation
+(i.e., these realisation will produce the same output files) which
+results in undefined behaviour.
+

--- a/doc/content/input_cmd.md
+++ b/doc/content/input_cmd.md
@@ -1,0 +1,221 @@
+## Command line options ##
+
+The following command line options must be specified when TSMP-PDAF is
+executed:
+
+### n_modeltasks ###
+
+`n_modeltasks` (integer) Number of realisations. Must be consistent
+with `[DA] nreal`.
+
+### filterype ###
+
+`filtertype` (integer) Type of filter used for data assimilation. For
+more details see the PDAF documentation. Currently, the following
+filter options are available
+
+-   (Ensemble Kalman Filter(Enkf)) is supported.
+
+-   (Ensemble Transform Kalman Filter(Etkf)) is supported.
+
+-   (Local Ensemble Transform Kalman Filter(Letkf)) is supported.
+
+-   (Error Subspace Transform Kalman Filter(Estkf)) is supported.
+
+-   (Local Error Subspace Transform Kalman Filter(Lestkf)) is supported.
+
+-   (Local Ensemble Kalman Filter(LEnkf)) is supported.
+
+To see all available command line options for the different filter
+algorithms please refer to PDAF wiki link
+
+<http://pdaf.awi.de/trac/wiki/AvailableOptionsforInitPDAF>
+
+### subtype ###
+
+`subtype` (integer) Parameter subtype, different options for each
+filter. See [Command Line Examples](#command-line-examples).
+
+### obs_filename ###
+
+`obs_filename` (string) Prefix for observation files.
+
+### rms_obs ###
+
+`rms_obs` (real) Measurement error.
+
+### delt_obs ###
+
+`delt_obs` (integer) Number of data assimilation intervals (see
+[`[DA]da_interval`](./input_enkfpf.md#dada_interval)) that are forward
+computed, before assimilation is actually performed.
+
+### screen ###
+
+`screen` (integer) Control verbosity of PDAF
+- 0: no outputs
+- 1: basic output (default)
+- 2: 1 plus timing output
+- 3: 2 plus debug output
+
+## Command Line Examples ##
+
+### Command Line Example: EnKF ###
+
+`subtype` (integer) Parameter subtype for Ensemble Kalman Filter (EnKF).
+
+-   Full ensemble integration; analysis for $2\cdot \mathtt{dim\_obs} > \mathtt{dim\_ens}$
+
+-   Full ensemble integration; analysis for $2\cdot \mathtt{dim\_obs} \leq \mathtt{dim\_ens}$
+
+-   Offline mode
+
+Example of the model execution using EnKF analysis:
+
+        mpiexec -np 512 ./tsmp-pdaf -n_modeltasks 64 -filtertype 2 -subytype 1 -delt_obs 1 -rms_obs 0.1 -obs_filename myobs
+
+With this command, the TSMP-PDAF executable `tsmp-pdaf` will be run with
+64 realisations (8 processors for each realisation) and EnKF analysis
+will be performed every assimilation cycle with an observation error of
+0.1 and observations read from the files `myobs.xxxxx`.
+
+### Command Line Example: ETKF ###
+
+`subtype` (integer) Parameter subtype for Ensemble Transform Kalman
+Filter (ETKF).
+
+-   full ensemble integration; apply T-matrix analogously to SEIK
+
+-   full ensemble integration; formulation without T matrix
+
+-   Fixed error space basis; analysis with T-matrix
+
+-   Fixed state covariance matrix; analysis with T-matrix
+
+-   Offline mode; analysis with T-matrix
+
+Example of the model execution using EtKF analysis:
+
+        mpiexec -np 512 ./tsmp-pdaf -n_modeltasks 64 -filtertype 4 -subytype 1 -delt_obs 1 -rms_obs 0.1 -obs_filename myobs
+
+With this command, the TSMP-PDAF executable `tsmp-pdaf` will be run with
+64 realisations (8 processors for each realisation) and EtKF analysis
+will be performed every assimilation cycle with an observation error of
+0.1 and observations read from the files `myobs.xxxxx`.
+
+### Command Line Example: ESTKF ###
+
+`subtype` (integer) Parameter subtype for Error Subspace Transform Kalman Filter
+(ESTKF).
+
+-   Standard implementation with ensemble integration
+
+-   Fixed error space basis
+
+-   Fixed state covariance matrix
+
+-   Offline mode
+
+Example of the model execution using EstKF analysis:
+
+        mpiexec -np 512 ./tsmp-pdaf -n_modeltasks 64 -filtertype 6 -subytype 1 -delt_obs 1 -rms_obs 0.1 -obs_filename myobs
+
+With this command, the TSMP-PDAF executable `tsmp-pdaf` will be run with
+64 realisations (8 processors for each realisation) and EstKF analysis
+will be performed every assimilation cycle with an observation error of
+0.1 and observations read from the files `myobs.xxxxx`.
+
+### Command Line Example: LETKF ###
+
+`local_range` (real) set localization radius, 0.0 by default, any
+positive value should work.
+
+`locweight` (integer) set weight function for localization, default=0
+for constant weight of 1; possible are integer values 0 to 4.
+
+`subtype` (integer) Parameter subtype for Local Ensemble Transform
+Kalman Filter (Letkf).
+
+-   full ensemble integration; apply T-matrix analogously to SEIK
+
+-   Fixed error space basis; analysis with T-matrix
+
+-   Fixed state covariance matrix; analysis with T-matrix
+
+-   Offline mode; analysis with T-matrix.
+
+Example of the model execution using Letkf analysis:
+
+        mpiexec -np 512 ./tsmp-pdaf -n_modeltasks 64 -filtertype 5 -local_range 3 -locweight 0 -subtype 0 -delt_obs 1 -rms_obs 0.1 -obs_filename myobs
+
+With this command, the TSMP-PDAF executable `tsmp-pdaf` will be run with
+64 realisations (8 processors for each realisation) and Letkf analysis
+will be performed every assimilation cycle with an observation error of
+0.1 and observations read from the files `myobs.xxxxx`.
+
+### Command Line Example: LESTKF ###
+
+`local_range` (real) set localization radius, 0.0 by default, any
+positive value should work.
+
+`locweight` (integer) set weight function for localization, default=0
+for constant weight of 1; possible are integer values 0 to 4.
+
+`subtype` (integer) Parameter subtype for Local Error Subspace Transform Kalman
+Filter (LESTKF).
+
+-   Standard implementation with ensemble integration
+
+-   Fixed error space basis
+
+-   Fixed state covariance matrix
+
+-   Offline mode
+
+Example of the model execution using Lestkf analysis:
+
+        mpiexec -np 512 ./tsmp-pdaf -n_modeltasks 64 -filtertype 7 -local_range 3 -locweight 0 -subtype 0 -delt_obs 1 -rms_obs 0.1 -obs_filename myobs
+
+With this command, the TSMP-PDAF executable `tsmp-pdaf` will be run with
+64 realisations (8 processors for each realisation) and Lestkf analysis
+will be performed every assimilation cycle with an observation error of
+0.1 and observations read from the files `myobs.xxxxx`.
+
+### Command Line Example: LENKF ###
+
+`local_range` (real) set localization radius (cut-off-radius)
+- 0.0 by default
+- any positive value should work.
+
+`srange` (integer): the support radius of the localization
+- the localization weight radius; support range for 5th-order
+  polynomial
+- by default set to `local_range`
+
+`locweight` (integer): set weight function for localization,
+- default=0
+- for constant weight of 1
+- possible are integer values 0 to 4.(see `init_pdaf`)
+
+``` text
+locweight == 0    ! Uniform (unit) weighting
+locweight == 1    ! Exponential weighting
+locweight == 2    ! 5th-order polynomial (Gaspari&Cohn, 1999)
+```
+
+`subtype` (integer) Parameter subtype for Localized Ensemble Kalman
+Filter (Lenkf).
+-   Full ensemble integration; analysis with covariance localization
+-   Offline mode
+
+Example of the model execution using Lenkf analysis:
+
+``` bash
+mpiexec -np 512 ./tsmp-pdaf -n_modeltasks 64 -filtertype 8 -local_range 3 -locweight 0 -subtype 0 -delt_obs 1 -rms_obs 0.1 -obs_filename myobs
+```
+
+With this command, the TSMP-PDAF executable `tsmp-pdaf` will be run
+with 64 realisations (8 processors for each realisation) and Lenkf
+analysis will be performed every assimilation cycle with an
+observation error of 0.1 and observations read from the files
+`myobs.xxxxx`.

--- a/doc/content/input_cos.md
+++ b/doc/content/input_cos.md
@@ -1,0 +1,17 @@
+## Input files for COSMO ##
+
+Currently, different COSMO realizations share the same input namelist
+files (`INPUT_`), except the namelist file for input/output
+specifications (`INPUT_IO`). The `INPUT_IO` namelist file names for
+the first three model realisation are:
+
+``` text
+INPUT_IO_00000
+INPUT_IO_00001
+INPUT_IO_00002
+```
+
+Within these different IO namelist files it is possible to assign
+different directories for the model input and output of the respective
+model realization.
+

--- a/doc/content/input_enkfpf.md
+++ b/doc/content/input_enkfpf.md
@@ -1,0 +1,375 @@
+## Control file `enkfpf.par` ##
+
+An additional file named `enkfpf.par` needs to be present in the
+TSMP-PDAF run directory.
+
+`enkfpf.par` is read by the routine `read_enkfpar` in
+`model/common/read_enkfpar.c`.
+
+`enkfpf.par` contains information about the different model components
+(ParFlow, CLM and data assimilation) like, e.g., the timing
+information of the models, the prefixes for the ParFlow/ CLM input
+files, etc.
+
+This input is structured in four sections: 
+- [`[PF]`](#pf) which holds information about ParFlow, 
+- [`[CLM]`](#clm) which holds information about CLM 
+- [`[COSMO]`](#cosmo) which holds information about COSMO
+- [`[DA]`](#da) which holds information about the data assimilation process
+
+An example for `enkfpf.par` is given below.  Note that the sequence of
+the entries within these four categories can be changed if desired.
+
+``` text
+[PF]
+problemname        = ""
+nprocs             =
+starttime          =
+dt                 =
+endtime            =
+simtime            =
+updateflag         =
+gwmasking          =
+paramupdate        =
+aniso_perm_y       =
+aniso_perm_z       =
+printensemble      =
+printstat          =
+paramprintensemble =
+paramprintstat     =
+olfmasking         =
+
+[CLM]
+problemname = ""
+nprocs      =
+update_swc  =
+update_texture  =
+print_swc   =
+print_et   =
+
+[COSMO]
+nprocs      =
+dtmult      =
+
+[DA]
+outdir = ""
+nreal =
+startreal =
+da_interval       =
+stat_dumpoffset   =
+point_obs =
+```
+
+In the following the individual entries of `enkfpf.par` are described:
+
+### [PF]
+
+#### PF:problemname
+`PF:problemname`: (string) Problem prefix for ParFlow.
+
+#### PF:nprocs
+`PF:nprocs`: (integer) Number of processors per ParFlow instance. Must
+match with the specifications in the `*.pfidb` input.
+
+This number of processors specifies a subset of the processors
+available in a single `COMM_model`. Each `COMM_model` contains - if
+there are no remainders - the following number of processes:
+`npes_world / nreal`.
+
+#### PF:starttime
+`PF:starttime`: (real) ParFlow start time. Must match with the
+specifications in the `*.pfidb` input (`TimingInfo.StartTime`).
+
+#### PF:dt
+`PF:dt`: (real) Length of ParFlow time step. Must match with the
+specifications in the `*.pfidb` input. 
+
+It is implicitly assumed that ParFlow and CLM calculate the same
+amount of time steps (i.e., have the same time step
+length). (Johannes: This may not be true, CLM time steps are computed)
+
+#### PF:endtime (deprecated)
+
+Deprecated. Use `PF:simtime` instead.
+
+`PF:endtime`: (real) Total simulation time (in terms of ParFlow
+timing). Must match with the specifications in the `*.pfidb` input.
+
+#### PF:simtime
+`PF:simtime`: (real) Total simulation time (in terms of ParFlow
+timing). 
+
+Must match with the specifications in the `*.pfidb` input.
+
+`PF:simtime` must correspond to `TimingInfo.StopTime` MINUS
+`TimingInfo.StartTime`!
+
+#### PF:updateflag
+`PF:updateflag`: (integer) Type of state vector update in ParFlow.
+
+-   1: Assimilation of pressure data. State vector consists of
+    pressure values and is directly updated with pressure
+    observations.
+
+-   2: Assimilation of soil moisture data. State vector consists of
+    soil moisture content values and is updated with soil moisture
+    observations. The updated soil moisture content is transformed
+    back to pressure via the inverse van Genuchten functions.
+
+-   3: Assimilation of soil moisture data. State vector consists of
+    soil moisture content and pressure values. Soil moisture data are
+    used to update pressure indirectly.
+
+#### PF:gwmasking
+`PF:gwmasking`: (integer) Groundwater masking for assimilation of
+pressure data (updateflag=1) in ParFlow.
+
+-   No groundwater masking.
+
+-   Groundwater masking using saturated cells only.
+
+-   Groundwater masking using mixed state vector.
+
+#### PF:paramupdate
+`PF:paramupdate`: (integer) Flag for parameter update
+
+-   0: No parameter update
+
+-   1: Update of saturated hydraulic conductivity
+
+-   2: Update of Mannings coefficient
+
+#### PF:aniso_perm_y
+`PF:aniso_perm_y`: (real) Anisotropy factor of saturated hydraulic
+conductivity in y-direction. Only used when hydraulic conductivity is
+updated (`[PF]paramupdate = 1`). Important: Compare this anisotropy
+factor with the corresponding anisotropy factor from
+ParFlow-input. Currently, we believe that the ParFlow-factor is used
+in the beginning of the simulation, while the factor set here, is used
+after each parameter update.
+
+#### PF:aniso_perm_z
+`PF:aniso_perm_z`: (real) Anisotropy factor of saturated hydraulic
+conductivity in z-direction. Only used when hydraulic conductivity is
+updated (`[PF]paramupdate = 1`). Important: Compare this anisotropy
+factor with the corresponding anisotropy factor from
+ParFlow-input. Currently, we believe that the ParFlow-factor is used
+in the beginning of the simulation, while the factor set here, is used
+after each parameter update.
+
+#### PF:printensemble
+`PF:printensemble`: (integer) If set to `1`, the updated state
+variables for all ensemble members is printed out as `pfb` files after
+each assimilation cycle.  Files are printed to `[DA]outdir` and follow
+the file naming convention of ParFlow. They include the specifier
+`update` in the file name.
+
+#### PF:printstat
+`PF:printstat`: (integer) If set to `1` (default) the ensemble
+statistics (mean and standard deviation) of the forecasted state
+variable are calculated and printed out as `pfb` files after each
+assimilation cycle. Files are printed to `DA:outdir` and follow the
+file naming convention of ParFlow. The output files include the
+specifiers `press.mean`/ `press.sd` in case of assimilated pressure
+update `PF:updateflag = 1` and the specifiers `swc.mean`/ `swc.sd` in
+case of assimilated soil moisture data `PF:updateflag = 2` or
+`PF:updateflag = 3`.
+
+#### PF:paramprintensemble
+`PF:paramprintensemble`: (integer) Only used in case of parameter
+update. If set to `1`, the updated parameters are printed to `pfb`
+files (similar to `[PF]printensemble`). Output files include the
+specifier `update.param`.
+
+#### PF:paramprintstat
+`PF:paramprintstat`: (integer) Only used in case of parameter
+update. If set to `1` statistics on the updated parameters are printed
+to `pfb` files (similar to `[PF]printstat`).
+
+#### PF:olfmasking
+`PF:olfmasking`: (integer) Only used in case you do not want to update
+the state on certain grid-cells during DA with pdaf. eg. not update
+the cell which is saturated. Option \"1\" means that all saturated
+cells at surface are not used for an update. Option \"2\" reads a pfb
+for masking the stream.
+
+### [CLM]
+
+#### CLM:problemname
+`CLM:problemname`: (string) Problem prefix for CLM
+
+#### CLM:nprocs
+`CLM:nprocs`: (integer) Number of processors for each CLM instance.
+
+This number of processors specifies a subset of the processors
+available in a single `COMM_model`. Each `COMM_model` contains - if
+there are no remainders - the following number of processes:
+`npes_world / nreal`.
+
+#### CLM:update_swc
+`CLM:update_swc`: (integer) Flag for update of soil moisture content
+in CLM (standalone only).
+
+-  0: No update of soil moisture content
+
+-  1: Update of soil moisture content
+
+- (only branch `TSMP_pdaf-crns`) 2: Update and average of soil
+  moisture content for use with Cosmic-Ray data (Hui Pung
+  implementation).
+
+- (only CLM5.0) 3: Update and average of soil moisture content for use
+  with Cosmic-Ray data (Strebel implementation of Schrön2017,
+  <https://research-information.bris.ac.uk/en/publications/improving-calibration-and-validation-of-cosmic-ray-neutron-sensor>).
+
+#### CLM:update_texture
+`CLM:update_texture`: (integer) Flag for update of soil parameter in
+CLM (standalone only).
+
+-  0: No update of soil parameter
+
+-  1: Update of soil parameter (clay or sand)
+
+-  (only CLM5.0) 2: Update of soil parameter (clay, sand or organic matter)
+
+-  (only CLM5.0) 3: Update of hydraulic conductivity log-transformed
+
+-  (only CLM5.0) 4: Update of hydraulic conductivity, porosity,
+   suction, hydraulic conductivity exponent B (see CLM5.0 technical
+   manual
+   <https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/index.html>)
+
+#### CLM:print_swc
+`CLM:print_swc`: (integer) If set to `1`, the updated soil moisture
+content in CLM for all ensemble members is printed out as `netcdf`
+files (one file per realisation for the whole simulation
+period). Files are printed to the run directory and are named
+according to the CLM problem prefix of the corresponding realisation
+and include the specifier `update` in the file name.
+
+#### CLM:print_et
+`CLM:print_et`: (integer) Invoke function `write_clm_statistics`. For
+further information, see source code.
+
+### [COSMO]
+
+#### COSMO:nprocs
+`COSMO:nprocs`: (integer) Number of processors for each COSMO
+instance.
+
+Currently, `COSMO:nprocs` is NOT USED by TSMP-PDAF. Instead, COSMO
+will get processors if there are processes left after giving
+`PF:nprocs + CLM:nprocs` processes to ParFlow and CLM.
+
+#### COSMO:dtmult
+`COSMO:dtmult`: (integer) Number of COSMO time steps within one
+ParFlow time step.
+
+### [DA]
+
+#### DA:outdir
+`DA:outdir`: (string) Directory where assimilation results should be
+written.
+
+#### DA:nreal
+`DA:nreal`: (integer) Number of realisations used in the
+simulation. `DA:nreal` Must be equal to command line input
+`n_modeltasks`.
+
+#### DA:startreal
+`DA:startreal`: (integer) Added to suffix-numbers for input file
+creation.
+
+#### DA:da_interval
+
+`DA:da_interval`: (double) Time interval (units of ParFlow timing,
+usually hours, check ParFlow input `TimingInfo.BaseUnit`,
+<https://parflow.readthedocs.io/en/latest/keys.html#timing-information>).
+
+After the time interval `da_interval` the forward simulation
+(integration) of all component models is stopped in the main loop of
+TSMP-PDAF (`pdaf_terrsysmp.f90`). Afterwards PDAF is called and it
+depends on the command line option `delt_obs` ([Command line
+options](./input_cmd.md#command-line-options)) whether data
+assimilation is performed during this iteration. `delt_obs` will
+specify the number of steps (loop iterations) that PDAF will iterate
+back to the forward simulation, before performing the actual data
+assimilation.
+
+One exception is that the observation file is empty at a data
+assimilation step. Then, no data assimilation takes place and the next
+set forward integration steps is executed.
+
+Formula for the simulation time between data assimilation steps (given
+non-empty observation files)
+
+\begin{gather*} 
+	t_{\mathtt{betweenDA}} =  \mathtt{da\_interval} \cdot \mathtt{delt\_obs} \cdot \mathtt{BaseUnit}
+\end{gather*}
+
+
+**Example 1 (FallSchoolCase):** `da_interval=1.0`, `delt_obs 12`,
+`TimingInfo.BaseUnit=1.0`. In this case, component models will be
+simulated for 12 1-hour-steps between data assimilation times. So an
+assimilation will be applied each 12 hours.
+
+**Example 2:** `da_interval=24.0`, `delt_obs 1`,
+`TimingInfo.BaseUnit=1.0`. In this case, component models will be
+simulated for 1 24-hour-step between data assimilation times. So an
+assimilation will be applied each 24 hours.
+
+#### DA:stat_dumpoffset
+`DA:stat_dumpoffset`: File number offset for the data assimilation
+output files for ParFlow.  Can be used when an assimilation run is
+restarted.
+
+#### DA:screen_wrapper
+`DA:screen_wrapper` (added 02/2022): Variable for controlling
+output. Analogous to `screen` variable for PDAF. Values: (0) no
+outputs, (1) medium outputs (default), (2) debugging output.
+
+#### DA:point_obs
+`DA:point_obs`: (integer) Only used in case of multiscalar data
+assimilation. Set to value 0 for using multiscalar data assimilation
+(eg. using SMAP satellite data over a large area which is not point
+data). If not specified its default value is set to 1, which is for
+using point observation for data assimilation run.
+
+### Parameter Summary
+
+ | section   | parameter            | value |
+ |:---------:|:--------------------:|:-----:|
+ | `[PF]`    |                      |       |
+ |           | `problemname`        | \-    |
+ |           | `nprocs`             | 0     |
+ |           | `starttime`          | 0.0   |
+ |           | `endtime`            | 0     |
+ |           | `simtime`            | 0     |
+ |           | `dt`                 | 0.0   |
+ |           | `updateflag`         | 1     |
+ |           | `paramupdate`        | 0     |
+ |           | `aniso_perm_y`       | 1.0   |
+ |           | `aniso_perm_z`       | 1.0   |
+ |           | `printensemble`      | 1     |
+ |           | `printstat`          | 1     |
+ |           | `paramprintensemble` | 1     |
+ |           | `paramprintstat`     | 1     |
+ |           | `olfmasking`         | 1     |
+ | `[CLM]`   |                      |       |
+ |           | `problemname`        | \-    |
+ |           | `nprocs`             | 0     |
+ |           | `update_swc`         | 1     |
+ |           | `print_swc`          | 0     |
+ | `[COSMO]` |                      |       |
+ |           | `nprocs`             | 0     |
+ |           | `dtmult`             | 0     |
+ | `[DA]`    |                      |       |
+ |           | `nreal`              | 0     |
+ |           | `outdir`             | \-    |
+ |           | `da_interval`        | 1     |
+ |           | `stat_dumpoffset`    | 0     |
+ |           | `screen_wrapper`     | 1     |
+ |           | `point_obs`          | 1     |
+
+Default values for parameter file `enkfpf.par`.
+

--- a/doc/content/input_oas.md
+++ b/doc/content/input_oas.md
@@ -1,0 +1,19 @@
+## Input files for OASIS-MCT ##
+
+When the component models of TSMP are coupled via OASIS-MCT, certain
+input files for the coupler need to be provided for a regular TSMP run.
+These files are principally the same for the execution of TSMP-PDAF and
+are shared among the different realisations. These input files include
+the file `namcouple` which defines the coupling between CLM and ParFlow,
+the netCDF file `clmgrid.nc` which is identical to the CLM input file
+containing the grid data (see CLM documentation) and the remapping files
+for the coupling (`rmp_.nc`). See the OASIS-MCT documentation for more
+details. It is important to note here that the remapping files should be
+created by a single deterministic TSMP run of the model. The so created
+remapping files should then be copied to the TSMP-PDAF run directory. If
+the remapping files are not present when TSMP-PDAF is executed, each
+realisation will try to create these files. However, because the naming
+convention for the OASIS-MCT remapping files is fixed, this would lead
+to an undefined overwriting of these files from the different
+realisations.
+

--- a/doc/content/input_obs.md
+++ b/doc/content/input_obs.md
@@ -1,0 +1,254 @@
+## Observation input ##
+
+Observation input consists of a number of different inputs:
+- Observation files with correct name and content
+- Command Line Options
+- Environment Variables
+
+### Observation files ###
+
+Observation files for TSMP-PDAF are netCDF files which follow a
+certain naming convention. Each observation file has a fixed prefix
+followed by the formatted number of the assimilation cycle which is
+determined by [`da_interval`](./input_enkfpf.md#dada_interval)
+. Additionally, the [command line
+input](./input_cmd.md#command-line-options) `delt_obs` determines the
+number of assimilation cycles/iterations/steps that are run purely
+forward before checking an observation file again.
+
+The prefix is chosen with the [command line
+option](./input_cmd.md#command-line-options) `obs_filename`.
+
+Example: If the chosen prefix is `myobs`, the observation files are
+named `myobs.00001, myobs.00002, myobs.00003`, etc.
+
+#### General observation file variables ####
+
+All observation files contain the following variable:
+
+##### dim_obs #####
+
+`dim_obs`: (int) The observation files contain one dimension named
+`dim_obs` which should be set equal to the number of observations for
+the respective assimilation cycle. The observation files for ParFlow
+should contain the following variables which all should have the
+dimension `dim_obs` (except variable `dr` in CLM observations files):
+
+#### ParFlow observation file variables ####
+
+If TSMP-PDAF is only applied with ParFlow, the following variables
+have to be specified in the observation files:
+
+##### obs_pf #####
+
+`obs_pf`: (real) Observations for ParFlow (either pressure or soil
+moisture)
+
+##### obserr_pf #####
+
+`obserr_pf`: (real) Observation errors which can be different for
+individual observations (optional). If this variable is not
+present. the command line option `rms_obs` (see [Command line
+options](./input_cmd.md#command-line-options)) will be used to define
+the observation error (equal for all observations).
+
+##### ix #####
+
+`ix`: (integer) Position of the observation in the ParFlow grid in
+x-direction.
+
+##### iy #####
+
+`iy`: (integer) Position of the observation in the ParFlow grid in
+y-direction.
+
+##### iz #####
+
+`iz`: (integer) Position of the observation in the ParFlow grid in
+z-direction.
+
+##### idx #####
+
+`idx`: (integer) Index of the observation in the ParFlow grid.
+
+The positions are always relative to the south-east corner cell at the
+lowest model layer. The index `idx` can be calculated as follows:
+
+\begin{gather*}
+	idx = (iz-1) \cdot nx \cdot ny + (iy-1) \cdot nx + ix
+\end{gather*}
+
+where `nx` and `ny` are the number of grid cells in x- and y-direction
+respectively and `ix`, `iy` and `iz` are the positions of the
+observation in x-, y- and z-direction.
+
+#### CLM observation file variables ####
+
+If TSMP-PDAF is only applied with CLM, different variables have to be
+specified in the observation files:
+
+##### obs_clm #####
+
+`obs_clm`: (real) Observations for CLM (soil moisture)
+
+##### obserr_clm #####
+
+`obserr_clm`: (real) Observation errors which can be different for
+individual observations (optional). If this variable is not
+present. the command line option `rms_obs` (see [Command line
+options](./input_cmd.md#command-line-options)) will be used to define
+the observation error (equal for all observations).
+
+###### lon ######
+
+`lon`: (real) Longitude of the observation.
+
+##### lat #####
+
+`lat`: (real) Latitude of the observation.
+
+##### layer #####
+
+`layer`: (integer) CLM layer where the observation is located (counted
+from uppermost CLM layer).
+
+##### var_id #####
+
+`var_id`: (integer) Only used for multiscalar data assimilation. Size
+of `var_id` is same as `dim_obs`. `var_id` has same values over model
+grid cells, which have range of similar observations values from raw
+data over them.  The values can be grouped starting from 1 for similar
+observation values to other integers (2,3,4,5 etc.) for other similar
+observations. If there are no observations over some grid cells than a
+negative `var_id` (integer) is assigned to them.
+
+##### dr #####
+
+`dr`: (real) Snapping distance for the observation. This variable
+should have a length of 1 instead of `dim_obs`
+
+Each of the CLM observations is snapped to the nearest CLM grid cell
+based on the given `lon`, `lat` and the snapping distance `dr` which
+should be smaller than the minimum grid cell size.
+
+### Multiscalar Data Assimilation ###
+
+The multiscalar data assimilation has been implemented for Local
+Ensemble Transform Kalman Filter(LETKF) filter (`filtertype=5`). For
+multiscalar data assimilation, we need to specify in `enkfpf.par` the
+entry `point_obs` (in `[DA]`) to value 0 (integer) for using
+multiscalar data assimilation (eg. using SMAP satellite data over a
+large area which is not point data).
+
+Then in the observation files we need to specify variable `var_id`
+values. Size of `var_id` is same as `dim_obs` . `var_id` has same
+values over model grid cells, which have range of similar observations
+values from raw data over them. The values can be grouped starting
+from 1 for similar observation values to other integers (2,3,4,5 etc.)
+for other similar obersvations. If there are no observations over some
+grid cells than a negative `var_id` (integer) is assigned to them.
+
+### Observation time flexibility ###
+
+Currently, in TSMP-PDAF there are a number input options that
+determine, when observations are read-in and assimilated:
+
+- [da_interval](./input_enkfpf.md#dada_interval)
+- [`delt_obs`](./input_cmd.md#delt_obs)
+- Parflow: `TimeInfo.BaseUnit`
+- Observation file NetCDF variable `no_obs`
+
+The goal of this section is to show how these inputs can be used to
+create a flexible observation time input.
+
+First, `da_interval` and `TimeInfo.BaseUnit` define the forward
+integration step that is executed during on iteration of the main
+TSMP-PDAF loop. This is the smallest time interval in your model and
+it determines the counter, also for observation file names. So
+`da_interval` should be small enough that each possible observation
+can be attributed to one timestep.
+
+Next, `delt_obs` is used to specify if data assimilation is not to be
+called at every iteration/cycle of `da_interval`. If two available
+observations are only `da_interval` apart, `delt_obs` has to be set to
+`1`. However, suppose observations daily at noon, and `da_interval` is
+one hour, then `delt_obs` could be chosen as `24`.
+
+Now, PDAF will be called every `delt_obs` iterations/cycles. However,
+there is one last way of manipulating observation input, by setting
+the NetCDF variable `no_obs` in the observation file to `0`. In this
+case, PDAF will skip the assimilation during that observation files
+cycle. So, in principle, one could set `delt_obs` to `1`, thus needing
+an observation file at every cycle. At each timestep that is not
+supposed to be assimilated, one could supply an alsmost-empty
+observation file with just a single variable `no_obs` that has the
+value `0`. By this workaround, one obtains a fairly flexible
+observation time input!
+
+Example code for setting variable `no_obs` to zero in an existing NetCDF
+file:
+```python
+import scipy.io as scio
+
+f = scio.netcdf_file("swc_obs.00001","a", mmap=False) # append
+f.variables["no_obs"].assignValue(0)
+f.close()
+```
+
+Example code for generating a minimal NetCDF observation file with
+just one variable `no_obs` set to zero:
+```python
+import numpy as np
+import scipy.io as scio
+
+f = scio.netcdf_file("swc_obs.00001","w", mmap=False) # write
+f.createDimension("dim_noobs", 1)
+f.createVariable("no_obs", np.int32, ["dim_noobs"])
+f.variables["no_obs"].assignValue(0)
+f.close()
+```
+
+### Specifying type of observation at compile time ###
+
+The following environment variables let the user specify the expected
+observational input (i.e. ParFlow or CLM observations) at compile time
+(during the build-process). This may save some time during execution
+as certain parts of the source code are not accessed at all.
+
+CLM observations: Set
+- [CLMSA](./build_environment_variables.md#clmsa)
+- [OBS_ONLY_CLM](./build_environment_variables.md#obs_only_clm)
+
+ParFlow observations: Set
+- [PARFLOW_STAND_ALONE](./build_environment_variables.md#parflow_stand_alone)
+- [OBS_ONLY_PARFLOW](./build_environment_variables.md#obs_only_parflow)
+
+#### Example for setting environment variables ####
+
+The aforementioned environment variables can be set in the PDAF-build
+script
+`TSMP/bldsva/intf_DA/pdaf1_1/arch/JURECA/build_interface_pdaf1_1_JURECA.ksh`
+(or replace `JURECA` with other machine).
+
+Source code from script `build_interface_pdaf1_1_JURECA.ksh`:
+```bash
+  if [[ $withCLM == "true" && $withCOS == "false" && $withPFL == "true" ]] ; then
+     importFlags+=$importFlagsCLM
+     importFlags+=$importFlagsOAS
+     importFlags+=$importFlagsPFL
+     importFlags+=$importFlagsDA
+     cppdefs+=" ${pf}-Duse_comm_da ${pf}-DCOUP_OAS_PFL ${pf}-DMAXPATCH_PFT=1 "
+     cppdefs+=" ${pf}-DOBS_ONLY_PARFLOW " # Remove for observations from both ParFlow + CLM
+     if [[ $readCLM == "true" ]] ; then ; cppdefs+=" ${pf}-DREADCLM " ; fi
+     if [[ $freeDrain == "true" ]] ; then ; cppdefs+=" ${pf}-DFREEDRAINAGE " ; fi
+     libs+=$libsCLM
+     libs+=$libsOAS
+     libs+=$libsPFL
+     obj+=' $(OBJCLM) $(OBJPF) '
+  fi
+```
+
+Here we see the flags that are set when the compilation flag `-c
+clm-pfl` is used. Interesting is the second line starting with
+`cppdefs+=...`. Here `OBS_ONLY_PARFLOW` is set. In analogous fashion,
+one of the other environment variables mentioned before could be set.

--- a/doc/content/input_pfl.md
+++ b/doc/content/input_pfl.md
@@ -1,0 +1,19 @@
+## Input files for ParFlow ##
+
+Similar to the input for CLM, the used has to create individual
+ParFlow data base files for each model realisation which share the
+same file name prefix. For example, if the chosen ParFlow file name
+prefix is `pfinput`, the file names for the first three model
+realisation are:
+
+``` text
+pfinput_00000.pfidb
+pfinput_00001.pfidb
+pfinput_00002.pfidb
+```
+
+As for the CLM input, the timing information contained in the ParFlow
+input files needs to be consistent among the different realisation.
+Other input information like initial conditions, parameters, etc. can
+differ between the realisations.
+

--- a/doc/content/installation.md
+++ b/doc/content/installation.md
@@ -1,0 +1,93 @@
+# Installing TSMP #
+
+## Obtaining the code ##
+
+### TSMP
+
+The source code of TSMP (Terrestrial System Modeling Platform) can be obtained from a git-repository hosted on Github:
+<https://github.com/HPSCTerrSys/TSMP>. On this website, a README file explains how to run TSMP for the first time on Linux.
+
+This git-repository provides wiki pages on how to download, configure and install TSMP. The latter two points are also explained in this manual in Sections [Build Examples](#build-examples) and [Setup](./setup_examples.md) for 
+convenience. Additionally, a few modifications need to be done for TSMP in order to work within TSMP-PDAF (*this patching is possibly not necessary anymore in the current version*).
+
+Commands for cloning from these repositories (https or ssh):
+
+```bash
+	git clone https://github.com/HPSCTerrSys/TSMP TSMP
+	git clone git@github.com:HPSCTerrSys/TSMP.git TSMP
+```
+
+More information about TSMP is available from the webpage:
+<https://www.terrsysmp.org/>
+and from the home page of the Centre for High-Performance Scientific Computing in Terrestrial Systems (HPSC-TerrSys):
+[http://www.hpsc-terrsys.de](http://www.hpsc-terrsys.de)
+
+There is also a public TSMP Virtual Machine available for download. This is a Ubuntu virtual machine containing TSMP and a tutorial on data assimilation. The webpage for downloading (TSMP Virtual Machine): <https://datapub.fz-juelich.de/slts/>
+
+### TSMP-PDAF
+
+Commands for cloning TSMP-PDAF (https or ssh):
+```bash
+	git clone -b TSMP-pdaf https://github.com/HPSCTerrSys/TSMP TSMP
+	git clone -b TSMP-pdaf git@github.com:HPSCTerrSys/TSMP.git TSMP
+```
+
+A second git-repository contains internal branches with current developments and is hosted by the Institute of Bio- and Geosciences
+Agrosphere (IBG-3) at the Forschungszentrum Jülich (registration required, contact jo.keller@fz-juelich.de):
+<https://icg4geo.icg.kfa-juelich.de>. 
+```bash
+	git clone https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp.git TSMP
+	git clone git@icg4geo.icg.kfa-juelich.de:ExternalRepos/tsmp-pdaf/tsmp.git TSMP
+```
+
+
+
+### PDAF
+
+The source code of PDAF is available from the following web page under Content-link `Software download` (registration required):
+<http://pdaf.awi.de/trac/wiki>. If possible, ask a senior institute member for existing versions on JSC systems.
+
+Install instructions are provided in the README files included in the downloadable archives. The installation procedure is currently not described in this user guide. The current version of TSMP-PDAF is build with PDAF version 1.13.2.
+
+The source code of TSMP-PDAF is available form the HPSC-TerrSys web site: [http://www.hpsc-terrsys.de](http://www.hpsc-terrsys.de)\ The
+new GIT-project "TSMP\" does not include the source code of the component models anymore.
+
+### Component Models
+
+The Github-page of TSMP does not include the source code of component models. This makes TSMP independent of third party code and licenses.
+
+Thus, with:
+
+``` bash
+	git clone https://github.com/HPSCTerrSys/TSMP TSMP
+```
+
+or (deprecated)
+
+``` bash
+	git clone https://git2.meteo.uni-bonn.de/git/terrsysmp TSMP
+```
+
+The standard root folder in this document is called `TSMP`.
+
+You are creating your root-folder `TSMP` including the subfolder `TSMP/bldsva` that holds the entire TSMP interface.
+
+All the source codes of component models should ideally be placed into one installation directory (for example the root folder `TSMP`).
+
+The directory structure of `TSMP` is discussed in more detail in Section [Structuring TSMP-PDAF](./structure.md).
+
+More information about availability of source code for model components can be found in the (outdated) wiki-page of
+<https://git2.meteo.uni-bonn.de/projects/terrsysmp/wiki/wiki>
+
+Updated information about obtaining source code for the component codes
+- this should not double the information on the Wiki or Github-page.
+
+Include obtaining from original sources and from Gitlab page
+<https://icg4geo.icg.kfa-juelich.de/ModelSystems>.
+
+For information on component models of TSMP-PDAF, see
+[https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/TSMP-PDAF-component-models](https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/TSMP-PDAF-component-models)
+
+## Build Examples ##
+
+Example builds of TSMP-PDAF: [Build Examples](./build_examples.md)

--- a/doc/content/intf_da.md
+++ b/doc/content/intf_da.md
@@ -1,0 +1,103 @@
+# Structure of DA inside TSMP #
+
+The directory `intf_DA` holds the interfaces of the component models
+to data assimilation frameworks (`dart`, `kenda` (currently not in
+`master`) and `pdaf1_1`) alongside scripts for building the data
+assimilation frameworks.
+
+The directory `intf_DA/pdaf1_1` contains build interface scripts and
+the interface code for coupling and running PDAF along with model
+component `clm3_5`, `parflow`, `parflow3_0`, `parflow3_2`, `oasis`,
+`oasis-mct` and `cosmo4_21`.  It has the following internal structure:
+
+``` text
+TSMP/bldsva/intf_DA/pdaf1_1/arch
+TSMP/bldsva/intf_DA/pdaf1_1/framework
+TSMP/bldsva/intf_DA/pdaf1_1/model
+TSMP/bldsva/intf_DA/pdaf1_1/tsmp
+```
+
+-   [`arch`](#arch) contains the configuration and build scripts for
+    different computers/clusters.
+	- Most important file(s): `build_interface_pdaf1_1_MACHINE.ksh`
+
+-   [`framework`](#framework) contains the interface to PDAF. 
+	- Most important file: `pdaf_terrsysmp.F90`.
+
+-   [`model`](#model) contains the wrapper/interface to the component
+	models.  In the subdirectories, there is component-model-specific
+	wrapper functions.
+	- Most important files: `wrapper_tsmp.c`, `Makefile`
+
+-   [`tsmp`](#tsmp) contains modified source files for `clm3_5`,
+    `parflow`, `parflow3_0`, `parflow3_2`, `oasis`, `oasis-mct` and
+    `cosmo4_21`. These source files are copied into the sources of the
+    component models, when PDAF is invoked and on top of the files
+    copied from `intf_oas3`.
+	- Most important file: `Makefile`
+
+## `arch` ##
+
+`arch` currently consists configuration and build scripts for the
+following five computers:
+
+``` text
+├── AGROCLUSTER
+├── GENERIC_X86
+├── JUQUEEN
+├── JURECA
+└── JUWELS
+
+5 directories, 0 files
+```
+
+The most tested versions are `JURECA` and `JUWELS`.
+
+Each computer-directory looks as follows (example `JURECA`):
+
+``` text
+├── build_interface_pdaf1_1_JURECA.ksh
+└── config
+    ├── linux_gfortran_openmpi_jureca.h
+    └── linux_ifort_jureca.h
+
+1 directory, 3 files
+```
+
+The build-script `build_interface_pdaf1_1_JURECA.ksh` contains the
+following functions. The script is source and the functions are called
+in `/TSMP/bldsva/build_tsmp.ksh` in the function `compileDA()`.
+
+- `always_da()`: 
+  - always executed, when DA is used (`$withDA=="true"`) ()
+  - up to now: dummy function, no effect
+  - `always_*` only used for OASIS3 for setting some directories
+- `substitutions_da()`
+  - make directory `$dadir/interface` (inside the newly generated
+    PDAF-directory-backup with build-suffix)
+  - copy directories [`model`](#model) (component model interface) and [`framework`](#framework) (PDAF interface)
+    into `interface`
+  - make directory `$dadir/lib` (make sure the empty `/lib` exists inside PDAF, this is where the static PDAF library `libpdaf-d.a` is written after compilation)
+- `configure_da()`
+  - configure three Makefiles (three-step process: (1)copying Makfiles
+    into compilation directories, (2) setting variables and then
+    overwriting dummy placeholders in the template makefiles), (3)
+    `make clean` for all Makefiles)
+	- `make.arch/linux_*.h`: PDAF machine-specific configuration
+	- `framework/Makefile`
+    - `model/Makefile`
+- `make_da()`
+  - three `make` commands
+	- PDAF source `src`
+    - PDAF `interface/model`
+    - PDAF `interface/framework`
+- `setup_da()`
+
+
+## `framework` ##
+
+## `model` ##
+
+## `tsmp` ##
+
+

--- a/doc/content/introduction.md
+++ b/doc/content/introduction.md
@@ -1,0 +1,96 @@
+# Introduction to TSMP & TSMP-PDAF #
+
+## TSMP 
+
+The Terrestrial System Modeling Platform (TSMP or TerrSysMP, https://www.terrsysmp.org) is an open source scale-consistent, highly modular, massively parallel regional Earth system model. TSMP essentially consists of an interface which couples dedicated versions of the Consortium for Small-scale Modeling (COSMO, http://www.cosmo-model.org) atmospheric model in NWP or climate mode, the Community Land Model (CLM, http://www.cesm.ucar.edu/models/clm/), and the hydrologic model ParFlow (https://www.parflow.org) through the OASIS3-MCT coupler (https://portal.enes.org/oasis, https://www.mcs.anl.gov/research/projects/mct/).
+
+TSMP allows as a fully integrated soil-vegetation-atmosphere modeling system for a physically-based representation of transport processes of mass, energy and momentum and interactions between the different compartments of the geo-ecosystem across scales, explicitly reproducing feedbacks in the hydrological cycle from the groundwater into the atmosphere.
+
+TSMP is extensively used for idealized and real data process and sensitivity studies in water cycle research, for climate change simulations, data assimilation studies including reanalyses, as well as experimental real time forecasting and monitoring simulations, ranging from individual catchments to continental model domains. TSMP runs on notebooks as well on latest supercomputers using a range of compilers.
+
+TSMP development has been driven by groups within the [Center for High-Performance Scientific Computing in Terrestrial Systems](http://www.hpsc-terrsys.de) (HPSC-TerrSys), as part of the [Geoverbund ABC/J](http://www.geoverbund-abcj.de/geoverbund/EN/Home/home_node.html), the geoscientific network of the University of Cologne, Bonn University, RWTH Aachen University, and the Research Centre Jülich. The current team is anchored in Jülich and Bonn in Germany.
+
+**Visit**
+
+**https://www.terrsysmp.org**
+
+**for information on the features of TSMP, ongoing developments, citation, usage examples, links to documentation, the team, contact information and publications.**
+
+## TSMP-PDAF 
+
+TSMP-PDAF describes the branches of the TSMP-repositories usable for TSMP simulations coupled with the Parallel Data Assimilation Framework ([PDAF](http://pdaf.awi.de/trac/wiki)).
+
+## Web Resources ##
+
+The main remote repository of TSMP is located on Github:
+
+- Github
+  ([https://github.com/HPSCTerrSys/TSMP](https://github.com/HPSCTerrSys/TSMP))
+
+On Gitlab is a clone with additional branches for TSMP-PDAF.
+
+- Gitlab
+  ([https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp](https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp))
+
+More information on the workflow around the remote repositories: [TSMP
+remote repositories](./remotes.md)
+
+Useful information for users, including a wiki and exercises, can be
+found among the resources for the Fall School HPSC Terrestrial
+Systems:
+[https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys](https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys).
+
+Additional information on TSMP can be found on the TSMP-website:
+[https://www.terrsysmp.org/](https://www.terrsysmp.org/).
+
+### Issues
+
+If you encounter any kind of problem with TSMP or TSMP-PDAF, do not hesitate to open in issue on Github under [https://github.com/HPSCTerrSys/TSMP/issues](https://github.com/HPSCTerrSys/TSMP/issues).
+
+## TSMP: Introduction from Website ##
+
+TSMP implements a physically-based representation of transport processes of water, energy and momentum across scales down to sub-km
+resolution including explicit feedbacks between groundwater, the land surface and atmosphere with a focus on the terrestrial hydrological and energy cycles. TSMP currently comprises three component models:
+The Consortium for Small-scale Modeling (COSMO) atmospheric model, the Comunity Land Model (CLM), and the hydrologic model ParFlow ParFlow coupled with OASIS3-MCT coupler and data assimilation capabilities through the Parallel Data Assimilation Framework (PDAF).
+
+TSMP is extensively used for idealized and real data process and sensitivity studies in water cycle research, for climate change
+simulations, data assimilation studies including reanalyses, as well as experimental real time forecasting and monitoring simulations, ranging from individual catchments to continental model domains.
+
+## Citing TSMP
+
+If you use TSMP in a publication, please cite the these papers that describe the model's basic functionalities:
+
+* Shrestha, P., Sulis, M., Masbou, M., Kollet, S., and Simmer, C. (2014). A Scale-Consistent Terrestrial Systems Modeling Platform Based on COSMO, CLM, and ParFlow. Monthly Weather Review, 142(9), 3466–3483. doi: [10.1175/MWR-D-14-00029.1](https://dx.doi.org/10.1175/MWR-D-14-00029.1).
+* Gasper, F., Goergen, K., Kollet, S., Shrestha, P., Sulis, M., Rihani, J., and Geimer, M. (2014). Implementation and scaling of the fully coupled Terrestrial Systems Modeling Platform (TerrSysMP) in a massively parallel supercomputing environment &ndash; a case study on JUQUEEN (IBM Blue Gene/Q). Geoscientific Model Development, 7(5), 2531-2543. doi: [10.5194/gmd-7-2531-2014](https://dx.doi.org/10.5194/gmd-7-2531-2014).
+
+For TSMP-PDAF additionally 
+* Kurtz, W., He, G., Kollet, S. J., Maxwell, R. M., Vereecken, H., & Hendricks Franssen, H. J. (2016). TerrSysMP–PDAF (version 1.0): a modular high-performance data assimilation framework for an integrated land surface–subsurface model. Geoscientific Model Development, 9(4), 1341-1360. doi: [10.5194/gmd-9-1341-2016](http://dx.doi.org/10.5194/gmd-9-1341-2016) 
+   
+
+## Relevant publications ##
+
+Papers describing the model physics or the technical implementation of the TSMP-PDAF components are summarized in the following table:
+
+| Model     | References    | Link (doi)                                                                                                                                 |
+|-----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| ParFlow   | @Ashby1996    | [http://dx.doi.org/10.13182/nse96-a24230](http://dx.doi.org/10.13182/nse96-a24230)                                                         |
+|           | @Jones2001    | [http://dx.doi.org/10.1016/s0309-1708(00)00075-0](http://dx.doi.org/10.1016/s0309-1708(00)00075-0)                                         |
+|           | @Kollet2006   | [http://dx.doi.org/10.1016/j.advwatres.2005.08.006](http://dx.doi.org/10.1016/j.advwatres.2005.08.006)                                     |
+|           | @Maxwell2013  | [http://dx.doi.org/10.1016/j.advwatres.2012.10.001](http://dx.doi.org/10.1016/j.advwatres.2012.10.001)                                     |
+| CLM3.5    | @Olefson2004  | [http://dx.doi.org/10.5065/D6N877R0](http://dx.doi.org/10.5065/D6N877R0)                                                                   |
+|           | @Oleson2008   | [http://dx.doi.org/10.1029/2007jg000563](http://dx.doi.org/10.1029/2007jg000563)                                                           |
+| COSMO     | @Baldauf2011  | [http://dx.doi.org/10.1175/mwr-d-10-05013.1](http://dx.doi.org/10.1175/mwr-d-10-05013.1)                                                   |
+| OASIS-MCT | @Valcke2013   | [http://dx.doi.org/10.5194/gmd-6-373-2013](http://dx.doi.org/10.5194/gmd-6-373-2013)                                                       |
+|           | @Valcke2013a  | [http://dx.doi.org/https://cerfacs.fr/code_coupling_with_oasis3-mct/](http://dx.doi.org/https://cerfacs.fr/code_coupling_with_oasis3-mct/) |
+| PDAF      | @Nerger2013   | [http://dx.doi.org/10.1016/j.cageo.2012.03.026](http://dx.doi.org/10.1016/j.cageo.2012.03.026)                                             |
+
+
+## Authors ##
+
+These authors contributed signficantly to this documentation before
+contributions were made transparent in the git history.
+
+- Wolfgang Kurtz
+- Fabian Gasper
+- Mukund Pondkule
+- Johannes Keller

--- a/doc/content/jsc.md
+++ b/doc/content/jsc.md
@@ -1,0 +1,14 @@
+# JSC systems #
+
+Information on JSC systems. Links to JCS-Websites.
+
+## Backups ##
+
+Backups: for `$PROJECT` under
+
+``` bash
+	/p/project/.snapshots
+```
+
+Otherwise: More information for how to restore files under
+https://www.fz-juelich.de/SharedDocs/FAQs/IAS/JSC/EN/JUST/FAQ_05_Restore_data.html?nn=2274286

--- a/doc/content/misc.md
+++ b/doc/content/misc.md
@@ -1,0 +1,311 @@
+# Misc #
+
+Various topics related to TSMP-PDAF.
+
+## Gitlab: TSMP-PDAF group ##
+
+The main repository of TSMP-PDAF is found on GitHub
+([https://github.com/HPSCTerrSys/TSMP](https://github.com/HPSCTerrSys/TSMP)).
+
+Additional development of TSMP-PDAF is organized on Gitlab in the
+group TSMP-PDAF:
+
+[https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf](https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf)
+
+### Repositories ###
+
+The Gitlab-group TSMP-PDAF currently contains the following
+repositories
+
+- `TSMP`: main repository, clone of GitHub TSMP from
+  [https://github.com/HPSCTerrSys/TSMP](https://github.com/HPSCTerrSys/TSMP)
+- `TSMP-PDAF Manual`: Repository for this manual.
+- `TSMP-PDAF Build Scripts`: Scripts for (remote) building of TSMP
+- `TSMP-PDAF Component Models`: Component Models used for building TSMP-PDAF
+- `TSMP-PDAF Testcases`: Testcases for TSMP-PDAF
+- `TSMP-PDAF Presentations`: Presentation slides for TSMP-PDAF
+
+## Open loop compilation of (TSMP-)PDAF ##
+
+For compiling TSMP-PDAF with PDAF but without data assimilation, you
+can set the flag `PDAF_NO-UPDATE` in Makefiles under
+`./TSMP/bldsva/intf_DA/pdaf1_1/arch/<machine>/config/<compiler>.h.`
+and in the line, where `CPP_DEFS` are set. Usually only `-DUSE_PDAF`
+is set, here you can add `-DPDAF_NO_UPDATE`.
+
+If you compile once with this flag and once without, you should obtain
+two build-versions of TSMP-PDAF, one for open-loop runs and one for
+data assimilation runs.
+
+## Scripts and other resources ##
+
+- Script for calculating discharge for ParFlow along the river network
+by Carina Furusho. Discharge can be calculated for each grid cell and
+each time step:
+<https://icg4geo.icg.kfa-juelich.de/ModelSystems/realpep_p4/blob/master/tools_postprocessing/functions_output_UNIVERSAL.py>
+
+
+# CLM5-PDAF Starting instructions
+
+## 1.  Install components
+
+The following instructions assume you are working on the JSC machine JURECA. If you are working on another JSC machine switch the name appropriately and the instructions should still work. Running CLM5-PDAF on non JSC machines is not covered in these instructions but should be similar if TSMP-PDAF, PDAF, and CLM5 can be installed on the machine. 
+
+### 1.1 TSMP-PDAF
+
+Clone the TSMP-PDAF repository to your work folder and switch to the CLM5-PDAF branch like this:
+
+```bash
+ git clone https://github.com/HPSCTerrSys/TSMP.git tsmp
+
+ cd tsmp
+
+ git checkout TSMP_pdaf-clm5
+```
+
+
+### 1.2 PDAF
+Get PDAF from [http://pdaf.awi.de/](http://pdaf.awi.de/) at least
+version 1.13 (suggested version 2.0) and unpack it in the tsmp
+directory and re-name the folder to `pdaf1_1`. 
+
+Users with internal IBG-3 access may also look here:
+[https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/pdaf2.0_fresh](https://icg4geo.icg.kfa-juelich.de/ModelSystems/tsmp_src/pdaf2.0_fresh)
+
+Example: On your local machine:
+
+```bash
+ scp your_local_download_folder/PDAF-D_V1.16.tar.gz your_username@jureca.fz-juelich.de:/full_path_to_your_tsmp_folder
+```
+
+On the JSC machine in the tsmp folder:
+
+```bash
+ tar -xzf PDAF-D_V1.16.tar.gz
+ mv PDAF-D_V1.16 pdaf1_1
+```
+
+### 1.3 CLM5
+
+Clone CLM5 and its dependencies from the official repo to the tsmp folder like this:
+
+```bash
+git clone -b release-clm5.0 https://github.com/ESCOMP/CTSM.git clm5_0
+
+cd clm5_0
+
+source ../bldsva/machines/JURECA/loadenvs.Intel
+
+./manage_externals/checkout_externals
+```
+
+- `source ...`: Loads the software environment on JURECA that is later
+  used for build with Intel
+- `./manage_externals/checkout_externals`: Loads dependencies of CLM5,
+  mostly a collection of `git clone` commands
+### 1.4 Compile the models together
+
+The TSMP framework works with its own build system. With the models in
+the folders as described before the compilation of both CLM5 and PDAF
+can be done with a single build command after the following
+preparations.
+
+If not already configured for CLM5 the following environmental
+variables are needed to compile CLM5 and can be for example be set
+like this:
+
+User defined data paths
+
+Path to the root directory for all CESM / CLM input files
+```bash
+export CESMDATAROOT=$SCRATCH/cesm
+```
+
+This is the default value set by the build process. However, you can
+export your own `CESMDATAROOT`.
+
+Path to the CSM specific input files (usually subfolder of CESMDATAROOT)
+
+```bash
+export CSMDATA=$CESMDATAROOT/inputdata
+```
+
+In the `tsmp/bldsva` directory:
+
+```bash
+./build_tsmp.ksh -v 4.4.0MCTPDAF -c clm -m JURECA -O Intel
+```
+
+Potential problems that can happen during this step:
+
+  * If you worked with CLM5 standalone and have created a `.cime`
+    folder in your home directory it can cause a conflict during
+    compilation. The error file will contain a line that says `ERROR:
+    No machine jureca found` for example. The easiest solution to this
+    is to move the `~/.cime` folder to `~/.cime_deactivated` while
+    working with CLM5-PDAF.
+  *  Using the newest software stages from JSC there is an import
+    conflict with bigint for PERL.  See
+    [https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp/-/issues/67](https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp/-/issues/67)
+    for details. The error message will contain a line like this:
+    `err=Can't locate bigint.pm in @INC`. The solution for now is to
+    comment all lines with `bigint` and `bignum` in the script
+    `tsmp/clm5_0/bld/config_files/clm_phys_vers.pm` since this is only
+    needed to check some version numbers the PERL modules is not
+    strictly needed.
+
+Once successfully compiled the executable can be found in path
+`tsmp/bin/JURECA_4.4.0MCTPDAF_clm/tsmp-pdaf`.
+
+## 2. File preparation
+
+For example files see [Example Case](#5-example-case).
+
+### 2.1 Ensemble generation
+
+For data assimilation with the ensemble Kalman filter we usually
+create an ensemble by perturbing the atmospheric forcing files as well
+as the sand and clay fractions in the surface file.
+
+For CLM5 how these files are named and numbered can be customized, as
+shown in the next section. But a recommended approach is to have a
+suffix with zero filled numbering like
+`surfdata_DE-Wue_hist_78pfts_CMIP6_simyr2000_c191001.nc_00001.nc`.
+
+The exact details of perturbation can vary from study to study, but a
+usable script to perturb the forcings and surface files can be found
+at
+`/p/largedata/jicg41/strebel2/CLM5PDAF_Example/perturb_forcings_and_soil_properties_in_range.py`.
+
+In this script the following variables should be modified or at least considered for modification before running it for your case.
+
+    * years (range of years for atm. forcing perturb)
+    * num_ensembles (how many ensemble members should be created)
+    * sname (path and naming for the output surface files)
+    * sorig (path for the original surface file)
+    * the attribute "perturbed by" (to indicate for future use who created the files)
+    * the values of the random.uniform function (range of perturbation for soil characteristics)
+    * sd, mean, and correl (the statistical characteristics for the atm. forcing perturbations)
+    * fname (path and naming for the original atm. files)
+    * outname (path and naming for the output atm. files)
+
+### 2.2 Case generation
+
+These instructions assume you already have a running CLM5 standalone
+case before moving to CLM5PDAF. If not instructions of how to generate
+the domain file, surface file, and download the default CLM5 inputfile
+can be found on the GitLab.
+
+We setup a new case in a new directory. In this directory we will need a few subfolders:
+
+```bash
+ mkdir logs
+
+ mkdir timing/checkpoints -p
+```
+CLM5-PDAF does not use the same case setup as CLM5 standalone, instead we skip to the final namelist files that are needed to run CLM5. The minimal set of namelists to run CLM5 is:
+
+    * atm_modelio.nml
+    * datm_in
+    * drv_flds_in
+    * drv_in
+    * esp_modelio.nml
+    * glc_modelio.nml
+    * ice_modelio.nml
+    * lnd_in
+    * lnd_modelio.nml
+    * mosart_in
+    * ocn_modelio.nml
+    * rof_modelio.nml
+    * wav_modelio.nml
+
+Since these files are needed for each ensemble member we create them with a script. An example of  such a script can be found at `/p/largedata/jicg41/strebel2/CLM5PDAF_Example/create_ensemble_namelists.py`
+
+In this script the following variables should be modified or at least considered for modification before running it for your case.
+
+    *  domain file (appears in write_datm_in(), as fatmlndfrc in write_lnd_in(), in write_stream_files() with path and name separated)
+    *  streams (in write_datm_in() modify to name of your case)
+    *  finidat (in write_lnd_in() your initial condition file from spinup)
+    *  fsurdat (in write_lnd_in() your surface files including ensemble numbering)
+    *  hist_mfilt, hist_nhtfrq (customize your history file settings)
+    *  filePath, fileNames (in write_stream_files customize the name and list of years for forcings)
+    *  name of the case (at the end of write_stream_files() needs to be consistent with the ones given in write_datm_in())
+    *  year_start, year_end (in main() give start and end year)
+    *  prefix (in main() for naming of output files)
+    *  num_ensemble (in main() number of ensemble members)
+    *  b_dir (in main() path to build directory of clm within tsmp)
+    *  r_dir (in main() path to the directory where the case will be run from i.e. the case directory)
+    *  Every other variable uses the default from a standalone CLM5 case, but may vary in your case, check the namelists in the run directory of your case against the variables listed in this script if you have customized the CLM5 case.
+
+The script at the moment can either be called without arguments if all
+variables are modified within the script or with year_start and prefix
+as arguments.
+
+To run PDAF an additional namelist is needed, enkfpf.par for details
+on the contents of this namelist refer to the TSMP-PDAF manual.
+
+Lastly, we create a symbolic link to the executable in the case
+directory. This way we do not create unnecessary copies of the
+executable for each case, we make sure that all cases are run with the
+same executable, and modification and re-compilations of the
+executable will not need any changes in the case directories. The
+symbolic link can be created like this:
+
+```bash
+ ln -s PATH_TO_THE_EXECUTABLE/tsmp-pdaf .
+```
+
+Similarly, we can use a symbolic link to the loadenvs file from TSMP to make sure we use the same module versions during runtime as during compilation.
+
+```bash
+ ln -s PATH_TO_THE_TSMP_FOLDER/bldsva/machines/JURECA/loadenvs.Intel loadenvs
+```
+
+## 3. Running the simulation
+
+To run the simulation we use can use a simple jobscript, an example can be found at `/p/largedata/jicg41/strebel2/CLM5PDAF_Example/jobscript_da.slurm`
+
+The arguments for the tsmp-pdaf executable are explained in the TSMP-PDAF manual.
+
+Important parameters are `-n_modeltasks` is the number of ensemble members and `nodes` times `ntasks-per-node` should be at least the same or a multiple of `n_modeltasks`. 
+
+The argument `-delt_obs` can be used to switch between open loop and DA simulation by increasing the value to be larger than the number of simulation steps set in `enkfpar.par` no assimilation will take place and the simulation will be an open loop ensemble simulation. 
+
+Additionally, `-obs_filename` has the path to the observations and the prefix of the observation files without the numbering.
+
+
+## 4. Post-processing the output
+
+CLM5-PDAF will create history files for each ensemble members
+according to the settings defined in the script
+`create_ensemble_namelists.py` with the hist variables. For large
+ensembles this will create a lot of files and should be processed and
+moved / archived away from `$SCRATCH` to avoid filling the number of
+files limit. One way to process the output is to collect the ensemble
+statistics of the variables in one file. An example script to perform
+this post-processing can be found at
+`/p/largedata/jicg41/strebel2/CLM5PDAF_Example/collect_some_ensemble_stats.py`
+
+The script should be modified before use, by changing the
+`collect_vars` variable to a list with the CLM5 variable names that
+should be collected. The output netcdf file will be called
+`Ensemble_Collection_` and contain the listed variables with their
+ensemble minimum, maximum, mean, and standard deviation.
+
+At the moment the script assumes that each year is in a separate
+history file, but could be customized to work on multi-year or less
+than a year files.  Currently, the script takes the arguments: year,
+OL or DA, num_ensemble, case name. Where case name refers to the
+previously mentioned prefix that can be used to differentiate between
+different simulations within the same case.
+
+## 5. Example case:
+
+All the input files necessary to create a 10 ensemble case for the
+year 2009 are located at
+`/p/largedata/jicg41/strebel2/CLM5PDAF_Example/Example_Case` and can
+be used to test the setup before working on your own case.
+
+
+
+

--- a/doc/content/pdaf.md
+++ b/doc/content/pdaf.md
@@ -1,0 +1,116 @@
+# Structure of PDAF inside TSMP
+
+## Call Graph for TSMP-PDAF
+
+Here is an exemplary call-graph from TSMP-PDAF's main program
+`pdaf_terrsysmp()` inside `pdaf_terrsysmp.F90` up to the function,
+where the enkf update is carried out:
+`PDAF_enkf_analysis_rlm`/`PDAF_enkf_analysis_rsm`.
+
+Inside TSMP, `TSMP/bldsva/intf_DA/pdaf1_1/framework`:
+
+``` text
+pdaf_terrsysmp.F90: pdaf_terrsysmp
+-> assimilate_pdaf.F90: assimilate_pdaf
+-> PDAF_assimilate_enkf
+```
+
+Inside PDAF, `pdaf1_1/src/`:
+
+``` text
+PDAF-D_assimilate_enkf.F90: PDAF_assimilate_enkf
+-> PDAF-D_put_state_enkf.F90: PDAF_put_state_enkf
+-> PDAF-D_enkf_update.F90: PDAF_enkf_update
+
+-> PDAF-D_enkf_analysis_rlm.F90: PDAF_enkf_analysis_rlm
+or
+-> PDAF-D_enkf_analysis_rsm.F90: PDAF_enkf_analysis_rsm
+```
+
+## Important Functions of TSMP-PDAF
+
+### `pdaf_terrsysmp` (main program)
+
+Subroutines:
+
+- `init_parallel_pdaf()`
+  1. `MPI_Init` if not yet done (should be done)
+  2. Set `npes_world`, `mype_world`
+  3. Read command line input: `n_modeltasks`
+  4. Initialize communicators for ensemble evaluations
+	- consistency checks `n_modeltasks > npes_world` and (not used
+since `dim_ens` is set to dummy-zero) `n_modeltasks > dim_ens`
+  5. `COMM_ensemble` (local copy of `MPI_COMM_WORLD`)
+  6. `COMM_model`: Generate communicators for model runs
+	 - Set `local_npes_model` depending on complete number
+       `npes_world` and `n_modeltasks`
+	 - Example: `mype_world=24` and 4 PEs per model, then mype_world
+       will be model task/color `9 = floor(24/4)+1` and rank `0`
+       (`25->1`, `26->2`, `27->3`).
+  7. `COMM_filter`: Same as `COMM_model`, but only first task used.
+  8. `COMM_couple`: For each rank in `COMM_model` (example 4 ranks),
+     there is a task in `COMM_couple` with `n_modeltasks` ranks
+     (example 48)
+  9. Finally `da_comm` is set to `COMM_model`; and
+     `cosmo_input_suffix` is set
+
+- [`initialize_tsmp()`](#initialize_tsmp)
+  1. read parameter file `enkfpf.par`
+  2. Set model number for a process
+  3. Set input function names
+  4. Call model-specific input functions
+	- `clm_init`
+	- `enkfparflowinit` (some more allocations in ParFlow part)
+    - `cosmo_init`
+
+### `initialize_tsmp()`
+
+File: `./bldsva/intf_DA/pdaf1_1/model/wrapper_tsmp.c`
+
+Subroutines:
+- `clm_init`
+  1. Setting `nlfilename` (essentially the same as `finname`?)
+  2. Initialize Communicators depending on mode
+  3. Initialize ESMF (needed for time-manager)
+  4. Initialize timing library, and set full path to namelist
+  5. Initialize Orbital parameters (`shr_orb_params`)
+  6. Initialize land model (`clm_init0, clm_init1, clm_init2`)
+  7. Initialize "external" atmospheric forcing (`atmdrv_init`)
+- `enkfparflowinit`
+  1. 
+
+## List of interesting variables of TSMP-PDAF
+
+- `local_npes_model`: PEs per ensemble
+- `n_modeltasks`: Number of parallel model tasks
+- `npes_world`: Number of MPI processes in `MPI_COMM_WORLD`
+- `mype_world`: Rank of calling process in `MPI_COMM_WORLD`
+- `pf_statevec`: ParFlow-Statevector in C-wrapper
+  - from `enkf_parflow.h` and set in `initialize_tsmp` from the
+    `wrapper_tsmp.c`
+- `pf_statevec_fortran`: ParFlow-Statevector in Fortran-part of
+  TSMP-PDAF
+  - defined in `init_pdaf.F90` by `C_F_POINTER` subroutine (Doc from
+    Gnu-Compiler:
+    https://gcc.gnu.org/onlinedocs/gfortran/C_005fF_005fPOINTER.html)
+  - takes values from `pf_statevec`
+- `subvec_p`: state vector pressure (from `enkf_parflow.c:371`)
+  - defined: `enkf_parflow.h`, allocated: `wrapper_tsmp.c`
+- `tag_model_clm`, (`0`), `tag_model_parflow` (`1`) and
+  `tag_model_cosmo` (`2`) identifiers for the component models
+    - defined `mod_tsmp.F90`
+    - used throughout TSMP-PDAF, for example in
+      `collect_state_pdaf.F90`
+
+### Model Communicators
+
+AMPS directory:
+-   ParFlow standalone: amps directory `da/` is used,
+-   Coupled ParFlow-CLM component models: amps directory `oas3/` is used.
+
+Variable names for the model communicator:
+-   ParFlow standalone:
+    -   `comm_model` -> C: `comm_model_pdaf` -> `pfcomm` (enkf_parflow/enkfparflowinit) -> `amps_CommWorld` (da/amps_init.c)
+-   Coupled with OASIS:
+    -   `comm_model` -> `da_comm` (init_parallel_pdaf) -> C: `fsubcomm` -> C-version not used
+    -   `comm_model` -> `da_comm` (init_parallel_pdaf) -> `mpi_comm_global` (mod_oasis_method)

--- a/doc/content/remotes.md
+++ b/doc/content/remotes.md
@@ -1,0 +1,72 @@
+# TSMP remote repositories #
+
+Relationship between the two remotes of the `TSMP` repository:
+
+- Github
+  ([https://github.com/HPSCTerrSys/TSMP](https://github.com/HPSCTerrSys/TSMP))
+- Gitlab
+  ([https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp](https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp))
+
+Technically the two servers are two remote servers of the same
+git-repository `TSMP`.
+
+This means that both repositories have the same history of commits and
+if you clone either remote repository, all branches that are part of
+both repositories are identical. The difference is that the
+Gitlab-remote contains additional branches, where TSMP-PDAF is
+developed.
+
+## Development scheme ##
+
+- Github: `TSMP` general development
+- Gitlab: `TSMP` is always kept up-to-date and changes are merged into
+  the `TSMP-PDAF`-related branches.  
+  
+See also [development best practices](./best_practices)
+
+## Privacy ##
+
+- Github: Completely open.
+- Gitlab: Only visible to invited members.
+
+
+## More in-depth Example ##
+
+Output of `TSMP`-git-repository's recent history including tags for
+local branches and branches from the two remote repositories `origin`
+(Gitlab) and `github` (Github):
+
+``` text
+*   05099a1 - (4 weeks ago)Merge branch 'master' into TSMP_pdaf_github - Johannes Keller (HEAD -> TSMP_pdaf, origin/TSMP_pdaf, github/TSMP_pdaf, TSMP_pdaf_github)
+|\
+| * 423ec0c - (4 weeks ago).gitignore: Ignore directories /cosmo4_21*/ - Johannes Keller (origin/master, github/master, github/HEAD, master-github, master)
+* | 786909f - (4 weeks ago)Merge branch 'master' into TSMP_pdaf_github - Johannes Keller
+|\|
+| * b7beccd - (4 weeks ago)upgrade to ParFlow3.7 with possibilty of heterogeneous job submission - Abouzar Ghasemi
+| * 8803904 - (4 weeks ago)upgrade to ParFlow3.7 with possibilty of heterogeneous job submission - Abouzar Ghasemi (tag: v1.3.3)
+* | 7a26c8b - (5 weeks ago)Merge branch 'master-github' into TSMP_pdaf - Johannes Keller (tag: v1.2.3PDAF, origin/TSMP_pdaf_v1.2.3, TSMP_pdaf_v1.2.3)
+|\|
+| * 3cc6477 - (5 weeks ago)Correcting machine file for JURECA - Abouzar Ghasemi
+| * 10a4cb3 - (6 weeks ago)Porting TSMP on JUSUF and JURECA_DC - Abouzar Ghasemi (tag: v1.2.3)
+| * 8d54475 - (7 weeks ago)Machine files for JUWELS compatible with Stage2020 (Intel) and Stage2019a (Gnu) - Abouzar Ghasemi
+* | 507714f - (8 weeks ago)compiler specific changes in src.Gnu / src.Intel in Oasis intf - Johannes Keller
+```
+
+Note that the commit `05099a1` is the current commit of the branches
+`TSMP_pdaf, origin/TSMP_pdaf, github/TSMP_pdaf, TSMP_pdaf_github`. In
+the local repository these are: 
+- The local branch `TSMP_pdaf`
+- the branch at remote origin (Gitlab) `origin/TSMP_pdaf`
+- the branch at remote github (Github) `github/TSMP_pdaf`
+- and the local version of the Github remote `TSMP_pdaf_github`
+(introduced for automatic pushing and pulling, should always be at the
+same commit as `TSMP_pdaf`).
+
+The commit `423ec0c` is the current commit of `origin/master,
+github/master, master-github, master` with similar meaning as before
+for the `TSMP_pdaf` branches.
+
+On commit `10a4cb3`, you see the tag `v1.2.3` for the version of
+`TSMP` before ParFlow3.7 was introduced. From this version the commit
+`7a26c8b` was derived with branches `origin/TSMP_pdaf_v1.2.3,
+TSMP_pdaf_v1.2.3`. These branches only exist on Gitlab!

--- a/doc/content/running.md
+++ b/doc/content/running.md
@@ -1,0 +1,42 @@
+# Running TSMP-PDAF #
+
+The execution of TSMP-PDAF and the necessary input is closely related
+to the one of TSMP. For executing TSMP, a ParFlow database file
+`*.pfidb` (see ParFlow documentation for more details), an input file
+for CLM (`lnd.stdin`) and several input files for OASIS-MCT and COSMO
+need to be present in the run directory. TSMP-PDAF follows a similar
+approach. The only difference is that for each realisation a different
+set of ParFlow/ CLM/ COSMO input files needs to be present which
+follow a certain naming convention (see Sections [Input files for
+CLM](./input_clm.md#input-files-for-clm), [Input files for
+ParFlow](./input_pfl.md#input-files-for-parflow) and [Input files for
+COSMO](./input_cos.md#input-files-for-cosmo)). Additionally, a control
+file for the data assimilation ([Control file
+`enkfpf.par`](./input_enkfpf.md#control-file-enkfpfpar)) and
+observation files ([Observation
+files](./input_obs.md#observation-files)) need to be present in the
+run directory.  Furthermore, some command line options ([Command line
+options](./input_cmd.md#command-line-options)) need to be specified
+when TSMP-PDAF is executed.
+
+See the Virtual Machine download on webpage
+<https://datapub.fz-juelich.de/slts/tsmp-vm/index.html>.
+
+The data on this website is quite large - `12.8 GB`.
+
+Only download this, if you really want to run the Virtual Machine!.
+
+```{toctree} 
+---
+maxdepth: 3
+caption: Inputs for TSMP-PDAF
+---
+input_clm.md
+input_pfl.md
+input_cos.md
+input_oas.md
+input_enkfpf.md
+input_obs.md
+input_cmd.md
+```
+

--- a/doc/content/setup_examples.md
+++ b/doc/content/setup_examples.md
@@ -1,0 +1,189 @@
+# Setup Examples #
+
+This Section need to be revised! Please take a look into the
+[FallSchool
+setup/configuration](https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys)
+to test your model.
+
+Active setups. Information on Backups by former colleagues
+[here](#backups)
+
+## Setup TSMP-PDAF ##
+
+For starting our data assimilation experiments with TSMP-PDAF, we will
+consider a down- scaled version of the test case described in Kurtz et
+al. (2016) which deals with a relatively simple land
+surface-subsurface problem. With this forward model we will perform
+experiments for the assimilation of soil moisture data including
+parameter estimation. This testcase is also available in the TSMP
+virtual machine or can be downloaded from gitlab in IBG-3
+institute. For external users you can contact Prof. Dr. Harrie-Jan
+Hendricks-Franssen at IBG-3 institute in Juelich Research Center.
+
+## Day4: Testcase FallSchool 2022
+
+Input files for the Testcase are found at
+[https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys/tsmp_pdaf_exercise_data](https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys/tsmp_pdaf_exercise_data)
+
+A detailed step-by-step explanation of how to build and run this setup
+is given at
+[https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys/fall-school-tutorials/-/wikis/Ensemble-Data-Assimilation](https://gitlab.jsc.fz-juelich.de/sdlts/FallSchool_HPSC_TerrSys/fall-school-tutorials/-/wikis/Ensemble-Data-Assimilation)
+
+### Build
+
+The common build for the Testcase FallSchool 2019 is [Compile
+Parflow + CLM with
+PDAF](./build_examples.md#compile-parflow-and-clm-with-pdaf). Choose the
+correct command for your machine and, if possible, the newest version.
+
+## CLM5 in TSMP setup: nrw_5x
+
+By Lukas Strebel
+
+Cloning `TSMP` and `CLM5`
+``` bash
+	git clone https://icg4geo.icg.kfa-juelich.de/ExternalRepos/tsmp-pdaf/tsmp.git TSMP
+	cd TSMP
+	git checkout clm5-coupling
+
+	git clone -b release-clm5.0.29 https://github.com/ESCOMP/ctsm.git clm5_0
+	cd clm5_0
+	./manage_externals/checkout_externals
+	cd ..
+```
+
+Build and setup commands
+``` bash
+	cd bldsva
+	./build_tsmp.ksh -v 4.4.0MCT -c clm -m JUWELS -O Intel
+	# wait until build is finished - can take some time
+	./setup_tsmp.ksh -v 4.4.0MCT -c clm -V nrw_5x -m JUWELS -O Intel
+	cd #Rundir given as last output line
+
+	# Change number of tasks / cores:
+	# change all *_ntasks = x in drv_in
+	# change nodes and task_per_node (and account for 1 node maybe increase time
+	# limit to 2h) in tsmp_clm_run.bsh and then finally:
+
+	sbatch tsmp_clm_run.bsh
+```
+If you want to submit multiple experiments at the same time, copy the full
+Rundir and do changes in individual folders. Otherwise one at a time and save
+timing folder between submits (is overwritten each time).
+
+## CORDEX on master branch
+
+TSMP with Stage2020 (with Intel and ParaStationMPI) for JUWELS is
+ready to clone. Please do note forget to add the option `-O Intel` for
+building and setup.
+
+- to clone:
+
+``` bash
+git clone https://github.com/HPSCTerrSys/TSMP.git
+```
+
+-to build:
+
+``` bash
+./build_tsmp.ksh -v 3.1.0MCT -c clm-cos-pfl -m JUWELS -O Intel
+```
+
+- to create Cordex test case:
+
+``` bash
+./setup_tsmp.ksh -v 3.1.0MCT -V cordex -m JUWELS -I _cordex -O Intel
+```
+
+## CORDEX with v1.3.3 with ParFlow3.7
+
+TSMP version v1.3.3 is now upgraded to use ParFlow3.7 with a
+possibility of submitting heterogeneous job (Cosmo and CLM on CPU and
+ParFlow on GPU). TSMP will only support ParFlow 3.7 from version
+v1.3.3 onward. Please read README in GitHub page for further
+information.  Those who want to do a quick test, submitting a
+heterogeneous job, please follow the instruction below:
+
+1-
+
+``` bash
+git clone https://github.com/HPSCTerrSys/TSMP.git
+```
+
+2- download the model components (except ParFlow3.7) and place them in
+TSMP root directory as written in "*Step 3*" of README".
+
+3-
+
+``` bash
+cd bldsva
+```
+
+4-
+
+``` bash
+./build_tsmp.ksh -v 3.1.0MCT -c clm-cos-pfl -m JUWELS -O Intel *-A GPU*
+```
+
+5-
+
+``` bash
+./download_data_for_test_cases.ksh
+```
+
+6-
+
+``` bash
+./setup_tsmp.ksh -v 3.1.0MCT -V cordex -m JUWELS -I _cordex -O Intel*-A GPU
+```
+
+*7- cd to run directory 8- modify the script `tsmp_slm_run.bsh`
+according to your project account and submit a job using `sbatch
+tsmp_slm_run.bsh`
+
+If you want to submit TSMP job on CPU (Cosmo, CLM and ParFlow run on
+CPU ), just drop `*-A GPU*` from build and setup commands.
+
+## Setups ###
+
+### Setup CORDEX test case for fully coupled TSMP on JUQUEEN with Oasis3-MCT ####
+
+      ./setup_tsmp.ksh -m JUQUEEN -c clm-cos-pfl -v 1.1.0MCT -V cordex
+
+The `-c` and `-v` flag are optional in this case because they default.
+
+### Setup NRW test case for ParFlow standalone on CLUMA2 ####
+
+      ./setup_tsmp.ksh -m CLUMA2 -c pfl -v 1.1.0MCT -V nrw
+
+The `-m` , `-v` and `-V` flag are optional in this case because they are
+default.
+
+### Setup NRW test case for new CLM4.0 + Cosmo5.1 on JURECA ####
+
+      ./setup_tsmp.ksh -m JURECA -c clm-cos -v 2.1.0MCT -C false
+
+The new models are currently only supported for clm-cos and with
+alternative coupling-scheme. 7.2.4) Setup NRW test case with 24h
+runtime, 3h wallclock time, latest(lets say 01.07.2016 00:00) Cosmo
+forcing, ParFlow and CLM restart, fully coupled on JURECA on `$WORK`
+
+      ./setup_tsmp.ksh -m JURECA -c clm-cos-pfl -v 1.1.0MCT -V nrw -r "$WORK/tsmp/nrw20160701/run" -Q 3 -T 24 -s 2016-07-01_00 -F "$WORK/tsmp/nrw20160701/cosforcing" -j "$WORK/tsmp/nrw20160630/run/clmoas.clm2.r.2016-06-30-00000.nc" -l "$WORK/tsmp/nrw20160630/run/rurlaf.out.press.00024.pfb"
+
+### Setup NRW test case with 20 member ensemble (parflow) on JURECA, but only use members 10-15. perturbed namelists reside in a special folder ####
+
+      ./setup_tsmp.ksh -m JURECA -c clm-cos-pfl -v 1.1.0MCT -V nrw -N 5 -n 10 -g "$HOME/ensemble/namelists/coup\_oas.tcl"
+
+Note, that even though you give the base namelist-name for the `-g`
+flag the actual namelists in this folder must be named like:
+`coup_oas.tcl_0`, `coup_oas.tcl_1`, `coup_oas.tcl_2`, etc.
+
+### Setup NRW spinup with init date (lets say 01.01.2005 00:00) 1 month runtime, 24h wallclock time, restart from arbitrary date (lets say 01.03.2005 00:00) in indexed (3rd) rundir on JURECA ####
+
+      ./setup_tsmp.ksh -m JURECA -c clm-cos-pfl -v 1.1.0MCT -V nrw -r "$WORK/tsmp/nrwSpinup/run" -I 3 -Q 24 -T 744 -s 2005-03-01_00 -S 2005-01-01_00 -j "$WORK/tsmp/nrwSpinup/run2/clmoas.clm2.r.2005-02-28-00000.nc" -k "$WORK/tsmp/nrwSpinup/run2/cosmo_out/lfff59000000" -l "$WORK/tsmp/nrwSpinup/run2/rurlaf.out.press.01416.pfb"
+
+
+
+## Backups ##
+
+- Zhenlei Yang: `icg4lts` under `DATAASSIMILATION/Zhenlei\ Yang`

--- a/doc/content/structure.md
+++ b/doc/content/structure.md
@@ -1,0 +1,709 @@
+# Structure of TSMP #
+
+After cloning TSMP into a directory, for example `TSMP`, you obtain a fixed top level folder structure. This folder structured is discussed in this section.
+
+## Component model directories and PDAF directory ##
+
+TSMP essentially consists of an interface which couples dedicated versions of the Consortium for Small-scale Modeling (COSMO,
+<http://www.cosmo-model.org>) atmospheric model in NWP or climate mode, the Community Land Model (CLM, <http://www.cesm.ucar.edu/models/clm/>), and the hydrologic model ParFlow (<https://www.parflow.org>) through the OASIS3-MCT coupler (<https://portal.enes.org/oasis>, <https://www.mcs.anl.gov/research/projects/mct/>).
+
+
+### TSMP framework 
+
+In the install directory `TSMP` the `bldsva` can be found, which contain all files of the `TSMP` framework (details below):
+``` text
+TSMP/bldsva
+```
+
+### TSMP component directory 
+
+The directories are called after the respectivel model component and ends with the version number of the model compoennt. 
+
+``` text
+TSMP/clm3_5
+TSMP/clm4_0
+TSMP/cosmo4_21
+TSMP/cosmo5_1
+TSMP/icon2_1
+TSMP/icon2_622
+TSMP/parflow
+TSMP/parflow3_0
+```
+
+The directories `clm3_5`, `clm4_0`, `cosmo4_21`, `cosmo5_1`, `parflow`, and `parflow3_0` contain the model source codes of the respective model components of TSMP.
+
+### OASIS3-MCT and PDAF directory
+
+The[ `bldsva`](#directory-bldsva-and-subdirectories) directory includes the scripts for configuring and compiling TSMP.
+
+The directories `oasis3` and `oasis3-mct` contain the source code of the OASIS3 and OASIS3-MCT coupler, resepectivly. `oasis3`  (without MCT) is deprecated and is no longer used in current versions of TSMP. 
+
+``` text
+TSMP/oasis3
+TSMP/oasis3-mct
+```
+
+After successfully downloading the three parts of TSMP-PDAF (TSMP-repository, PDAF, component models), rename PDAF-source folder
+called `PDAF-D_V1.13.2` to `pdaf1_1`.
+
+The directory `pdaf1_1` contains the PDAF source code.
+
+``` text
+TSMP/pdaf1_1
+```
+
+### Example
+
+The following directory structure should be present in the install directory `TSMP` in case you want to run a fully coupled `TSMP` with COSMO5_1, CLM3_5 and ParFlow:
+``` text
+TSMP/bldsva
+TSMP/clm3_5
+TSMP/cosmo5_1
+TSMP/parflow
+TSMP/oasis3-mct
+```
+
+## Directory `bldsva` and subdirectories ##
+
+``` text
+TSMP/bldsva/data_oas3
+TSMP/bldsva/intf_DA
+TSMP/bldsva/intf_oas3
+TSMP/bldsva/machines
+TSMP/bldsva/setups
+```
+
+### data\_oas3
+
+The directory `data_oas3` holds files with static parameters, namely all
+variants of the `namcouple` file and `cf_name_table.txt`.
+
+### intf\_oas3
+
+Holds the interfaces of the component models and scripts to build them.
+This folder again holds sub-folders with one for each component model
+version that is available.
+
+``` text
+TSMP/bldsva/intf_oas3/clm3_5
+TSMP/bldsva/intf_oas3/clm3_5-icon
+TSMP/bldsva/intf_oas3/clm4_0
+TSMP/bldsva/intf_oas3/cosmo4_21
+TSMP/bldsva/intf_oas3/cosmo5_1
+TSMP/bldsva/intf_oas3/icon2-1
+TSMP/bldsva/intf_oas3/icon2-622
+TSMP/bldsva/intf_oas3/oasis3
+TSMP/bldsva/intf_oas3/oasis3-mct
+TSMP/bldsva/intf_oas3/parflow
+TSMP/bldsva/intf_oas3/parflow3_0
+```
+
+Each component model folder contains itself a subset of the following
+subfolders, as an example take `clm3_5`:
+
+``` text
+TSMP/bldsva/intf_oas3/clm3_5/arch
+TSMP/bldsva/intf_oas3/clm3_5/mct
+TSMP/bldsva/intf_oas3/clm3_5/oas3
+TSMP/bldsva/intf_oas3/clm3_5/pfile  (only clm3_5, possibly deprecated; currently not used)
+TSMP/bldsva/intf_oas3/clm3_5/tsmp
+```
+
+-   `arch`: This folder contains a sub-folder for every machine on which
+    the component model is supported, f.e. `JURECA` and `JUWELS`.
+
+    Each of the machine-folders then contains 2 optional folders:
+
+    1.  `config`, which includes makefiles, configure scripts,
+        machine-dependent build files etc, and
+
+    2.  `src` which contains machine specific source code modifications.
+
+-   `tsmp`: This folder holds source code modifications that need to be
+    made in the component model for every machine (not only for specific
+    machines as the modifications in `/arch/*/src/`).
+
+-   `oas3`: This folder holds source code of the interface between the
+    component model and oasis.
+
+-   `mct`: This folder holds source code that is only needed when using
+    Oasis3-MCT.
+
+### machines
+
+Holds scripts with machine specifications and also scripts to load
+modules among other configurations. This folder has one sub-folder for
+all supported machines.
+
+### setups
+
+Holds scripts to specify experiment setups and namelist templates for
+this particular setup. This folder has one sub-folder for each supported
+setup
+
+### `intf_DA`
+
+See [Structure of DA inside TSMP](./intf_da.md)
+
+## Shell Scripts in `bldsva` ##
+
+The following files reside under `$tsmp_root`/bldsva/:
+
+-   [`build_tsmp.ksh`](#shell-script-build_tsmpksh)
+
+-   [`setup_tsmp.ksh`](#shell-script-setup_tsmpksh)
+
+-   `supported_versions.ksh`
+
+-   `download_data_for_test_test_cases.ksh`
+
+The two important scripts to automatically build TSMP and setup an
+experiment are
+
+``` text
+build_tsmp.ksh
+setup_tsmp.ksh
+```
+
+There will be no explicit user documentation, since both scripts include
+a man-page styled output by calling the individual script with the
+option `–man`.
+
+``` bash
+./build_tsmp.ksh --man
+./setup_tsmp.ksh --man
+```
+
+The shell script `supported_versions.ksh` that contains the supported
+versions of the TSMP instance is described in the following
+subsection.
+
+The script `download_data_for_test_test_cases.ksh` simplifies working
+through the `README.md` of TSMP by automating the download of the
+CORDEX test case input data.
+
+### `supported_versions.ksh`
+
+This script is a source list of supported machines and configurations.
+It is called by running the main scripts with option `-a` / `–avail`:
+
+``` bash
+./build_tsmp.ksh -a
+./setup_tsmp.ksh -a
+```
+
+The output includes:
+
+-   for `./build_tsmp.ksh`: A list of supported machines including the
+    information which version is available on which machine; a list of
+    versions including the information of which combinations of
+    component models is available for each version and the directory
+    names of the component model versions of each TSMP version.
+
+-   for `./setup_tsmp.ksh`: The information from before and additionally
+    the available setups for each TSMP-version and a list of setups with
+    short documentation. Setups are automatically build test cases for
+    TSMP.
+
+The dictionaries containing all information in `supported_versions.ksh`
+are implemented as `ksh-associative-array`. These dictionaries are used
+by other scripts as well, for example for sanity checks, as possible
+user choices in the interactive mode and for naming conventions.
+
+Whenever you pass a machine-name, version, combination, setup, etc. as a
+flag or need to know the folder name of a component-model make sure it
+is identically written as in this script (case sensitive).
+
+Some array entries are string lists and are converted to a list later
+on. Make sure these lists start and end with a space (see comments in
+this file).
+
+        # IMPORTANT: add a leading and trailing " "(space)
+
+The spaces are necessary because strings might be parsed with spaces,
+i.e. as ` value`. If a default is necessary the first entry of a string
+list will be taken.
+
+With versions you have a variety of options to constrain your support.
+For example you could create a special version that is only supported on
+a certain machine. This version then consists of special
+component-model-versions and might only allow certain combinations (for
+example only standalone - if MPMD is not supported).
+
+One special naming convention I introduced is for Oasis3-MCT coupling.
+Oasis3-MCT is used if \"MCT\" is somehow part of the version-name. (One
+could think about adding this information as a flag, but for now I
+decided not to do so.)
+
+## Shell Scripts in subdirectories ##
+
+### `intf_oas3/common_build_interface.ksh`
+
+This file has the only intention to reduce duplicate code. It is sourced
+by the main-scripts and thus available in all subscripts. I outsourced
+code to this file that is the same amongst different versions of a
+component-model and amongst different machines. Since many things are
+similar between model-versions/machines this lowers the complexity of
+adding a new model a lot.
+
+If you add a new machine/model-version and encounter inconsistencies
+between this file and your commands you are responsible to solve it.
+Either by removing the inconsistent commands from the
+`common_build_interface` to the \"real\" interfaces of the form
+`intf_oas3/MODEL/arch/ARCH/build_interface_MODEL_ARCH.ksh` (f.e.
+`intf_oas3/clm3_5/arch/JUWELS/build_interface_clm3_5_JUWELS.ksh`). If a
+lot is inconsistent you can simply not make use of the common interface.
+
+### `intf_oas3/MODEL/arch/ARCH/build_interface_MODEL_ARCH.ksh`
+
+This is the \"real\" interface to compile a specific model on a specific
+machine and to handle namelist substitutions.
+
+As you see by the location in the directory tree
+(`intf_oas3/MODEL/arch/ARCH/`), there must be a script for every
+supported model-platform combination (`MODEL` and `ARCH` ). The script
+`build_interface_MODEL_ARCH.ksh` must implement 5 interface routines:
+
+-   `always_MOD()`,
+
+-   `configure_MOD()`,
+
+-   `make_MOD()`,
+
+-   `substitution_MOD()`,
+
+-   `setup_MOD()`, where `MOD`
+    $\in \{\mathtt{clm},\mathtt{cos},\mathtt{oas},\mathtt{pfl}\}$
+
+`always_MOD()`: in this routine stuff is handled that always needs to be
+done even if compilation is skipped. An example is declaring paths to
+oasis libs in [always\_oas()]{.roman}.
+
+`configure_MOD()`: this routine handles everything that is needed to
+configure or to create Makefiles. It also edits Makefile-templates after
+creation. It is important that also config file-templates are always
+copied from the config folder in order to have a fresh template before
+editing.
+
+`make_MOD()`: this routine calls `make` and starts compiling and moves
+the created executables to a bindir.
+
+`substitution_MOD()`: This routine substitutes source code that is
+unchanged for this configuration and is independent from
+making/configuring (other than in `configure_MOD()`). This is usually
+the whole `oas3` and `tsmp` folder or the `src` folder.
+
+`setup_MOD()`: This routine handles the creation of necessary files for
+the run. In especially editing the namelist template. And also execute
+the namelist.
+
+The ParFlow `tcl` file and the Cosmo `lmrun_uc` always needed to get
+executed. But now also the clm namelist needs an execution (compare with
+`lnd.stdin` in nrw setup). This was necessary for `clm4_0` and also for
+ensembles.
+
+Most of these routines call a function with the same name but with
+leading `c_` for example `c_configure_oas()`. This is the according
+routine in the
+[`common_build_interface.ksh`](#intf_oas3common_build_interfaceksh)
+and handles stuff that is the same throughout versions/machines.
+
+### `machines/ARCH/build_interface_ARCH.ksh`
+
+This script must implement 3 interface routines:
+
+-   `getMachineDefaults()`,
+
+-   `finalizeMachine()`
+
+-   and `createRunscript()`.
+
+In `getMachineDefaults()` some variables need to be defined, basically
+loading modules (or executing a load-script) but also the location of
+the libraries that are necessary for compiling. Plus some additional
+things like default optimization or profiling on this machine (not yet
+supported). This routine is used by the interactive mode to pre-load the
+values. Because of that this routine might get called several times.
+
+For this reason it is separated from `finalizeMachine()`. It was
+supposed to do fixed steps, after a selection was made. Originally it
+was planned to load the modules there, but it turned out that this was
+mostly also necessary for the first step in order to get library-paths.
+It is still used by some machines.
+
+In `createRunscript()` the runscript for a job scheduler on this machine
+is created. It calculates processor-distribution and also creates
+map-files if needed. It also creates the `instanceMap.txt` which is used
+for ensemble runs.
+
+Ensemble runs are currently only supported if Oasis3-MCT is used as
+coupler. Ensembles also increase the used processors (as given) by the
+factor of ensemble members.
+
+### `setups/SETUP/SETUP_ARCH_setup.ksh`
+
+This script must implement two interface routines:
+
+-   `initSetup()`
+
+-   and `finalizeSetup()`
+
+In `initSetup()` some variables need to be defined, basically values
+that are needed to fill the namelist-templates. These might be optional
+if they are not needed for the template. But others are mandatory like
+namelist-location, forcing-dir etc. Some variables only serve as default
+and might get overwritten by the main-scripts (usually start with
+\"default\").
+
+This routine is used by the interactive mode to pre-load the values.
+Because of that this routine might get called several times.
+
+For this reason it is separated from `finalizeSetup()` where
+setup-specific edits to the run-directory is done. For example copying
+files like rmp-files or parflow slope-files and other resource files
+that are not common to all experiments.
+
+## Shell script `build_tsmp.ksh` ##
+
+This script does everything that is needed to build (create executables)
+a given version of TSMP for on certain machine with a certain
+model-combination.
+
+### Routines
+
+#### `getDefaults()`
+
+This section serves as hardcoded defaults. All necessary variables are
+here defined as a default version `def_...`. They will be used if they
+are not overwritten by flags or interactive modifications.
+
+This section is intended to be modified also by users. It is useful if
+you are always using a specific setup and don't want to type a lengthy
+command every time. Note that by running the script without argument
+flags it will start the interactive session. But with providing the flag
+`-b` the batch mode is forced. Thus, with `./build_tsmp.ksh -b` only the
+hardcoded defaults of this section will be used.
+
+#### `setDefaults()`
+
+This section copies the hardcoded default of the previous session into
+the \"real\" data structure/variables.
+
+Some variables need a decision. If they are not hardcoded in the
+previous section and not given as flag/interactively a decision is made
+in this routine (really hard coded). Most importantly `platform=CLUMA`
+and `version=1.1.0MCT`.
+
+#### `clearMachineSelection()`
+
+This is only necessary for handling the interactive mode. If the
+platform is switched during the interactive session some variables needs
+to be cleared.
+
+#### `clearPathSelection()`
+
+This is only necessary for handling the interactive mode. If some paths
+(fore example root) are switched during the interactive session some
+variables needs to be cleared.
+
+#### `setSelection()`
+
+If a new machine is chosen (at the beginning or during interactive
+session) machine dependent default variables are getting read from
+`machines/ARCH/build_interface_ARCH.ksh`.
+
+Note: They will only loaded if this values were not set in any other
+selection (like interactive/flag/hardcoded).
+
+#### `finalizeSelection()`
+
+Doing stuff after selections were made. Currently only creating a
+bindir.
+
+Questionable if this routine is necessary anymore.
+
+#### `setCombination()`
+
+This routine is setting the `withMOD` variables depending on the chosen
+combination. This routine was designed to be flexible with the
+combination options. But other routines are hindering this flexibility
+anyways.
+
+This routine needs a revision.
+
+#### `compileClm()`
+
+Compiles CLM. It will first source the `build_script` for the selected
+machine and then calls the interface. Which interface routines are
+called is dependent of the chosen build option (`skip`, `fresh`,
+`build`, `configure`, `make`). If `fresh` (default) is chosen, also a
+backup is made.
+
+#### `compileCosmo()`
+
+Analog to `compileClm()`
+
+#### `compileOasis()`
+
+Analog to `compileClm()`
+
+#### `compileParflow()`
+
+Analog to `compileClm()`
+
+#### `runCompilation()`
+
+Determines which models are part of the selected combination and above
+functions are called.
+
+#### `interactive()`
+
+Handles the interactive session. Reads selections from the console and
+pushes return values to the desired variables. Some Variables need extra
+handling, in especially if dependencies follow. For example `machine`,
+`version`, `rootdir`, etc.
+
+#### `printState()`
+
+Prints all selectable variables. This is used by the interactive mode
+and as debug information for the log.
+
+#### `check()`
+
+Helper function to check the `$?` return value of each command.
+
+#### `terminate()`
+
+Clean exit handling.
+
+#### `comment()`
+
+Prints to log and terminal. Usual approach for every system call is to
+comment the action and append a `check()` to make sure no error
+happened.
+
+#### `route()`
+
+An call that should be made as first and last action of a routine to get
+output in which routine the script currently is (debugging).
+
+#### `warning()`
+
+If some sanity checks trigger it is asked for a decision to continue on
+own responsibility.
+
+####  `hardSanityCheck()`
+
+Exits if incompatible decisions were made.
+
+####  `softSanityCheck()`
+
+Gives warning if decisions are not supported but could work if it was
+taken care of. For example setups/combinations that are not in the
+`supported_machine.ksh`.
+
+####  `listAvailabilities()`
+
+Returns a human readable output of supported machines/combinations etc
+basically everything that is given in `supported_machines.ksh`. Script
+will exit without modifications afterwards.
+
+#### `listTutorial()`
+
+Returns a tutorial. Probably not sufficient enough. Script will exit
+without modifications afterwards.
+
+#### `getRoot()`
+
+Determines the root-directory out of pwd and call-command. Working on
+usual Linux.
+
+#### `MAIN()`
+
+Starts with determining root and loading defaults. Then handling the
+command line flags. Then doing sanity checks and sourcing machine-script
+based on flags. Then starting the interactive session. Then finalizing
+the selection and starting the compilation. At the end doing some
+cleanup and logging.
+
+### Features
+
+#### Layers of defaults and selections
+
+We have two kinds of defaults: Hardcoded defaults from
+[`getDefaults`](#getdefaults) (starting with `def_`) and some machine-
+and setup specific defaults (starting with `default...`) in the setup-
+and machine-interfaces. Then there is the batch-mode which overwrites
+existing values with command-line flags and the interactive mode which
+will be started if no flags are given.
+
+The hierarchy of overwriting is:
+
+    defaults... < def_ < batch-mode < interactive-mode.
+
+Even if providing flags, the interactive mode can be forced with `-i`
+flag. Additional flags will then be pre-selected in the interactive
+mode.
+
+#### Logging and debugging
+
+Three log files are created during the build and setup script.
+
+`log_all_$DATE` -- stores all std-output that is generated by system
+calls and executing external scripts (like `make` etc.) This output is
+not shown while scripts run.
+
+`err_all_$DATE` -- stores all err-output that is generated by system
+calls and executing external scripts (like `make` etc.) This output is
+not shown while scripts run.
+
+`stdout_all_$DATE` -- stores the output of the script (which you also
+see on screen when scripts run)
+
+Usually, a comment output is written to `stdout_*` before system
+calls. 
+
+After execution, the system call is usually checked by
+[`check()`](#check). If errors are found, the build is terminated.
+
+Additionally, every function entry and exit is logged. 
+
+**Debugging Tip**: If a check fails the script stops and it is
+immediately visible in which routine and call it failed. Thus, the
+output in `stdout_*` is a good starting point for finding the location
+in `TSMP`, where an error occurred during building.
+	
+</details>
+
+
+#### Sanity checks
+
+2 types of sanity checks exist, hard and soft.
+
+Hard: The script need to know the machine, version and setup. Otherwise
+it does not know what files to source. Thus, if an unsupported
+version/machine/setup is given the script will exit.
+
+Soft: Combinations and model versions might work even if not supported/
+or under development. An warning will be shown with the option to quit
+or continue. Furthermore, during the interactive session only supported
+selections will be given as option.
+
+#### Build options
+
+Currently the following build options are implemented to provide
+flexibility for debugging/porting/tuning/source modifications.
+
+`skip`: the model is part of the combination, but it is already compiled
+and further compilation can be skipped.
+
+`fresh`: the model needs to be build completely and is also backed up to
+a new folder. The source folder remains untouched. Also the model source
+must lie under `$root/model` (as in the catalog).
+
+`build`: the model needs to be build completely but in the original
+folder/or the folder-name that is given to `-wxyz` flags.
+
+`configure`: the model is only configured. New set of
+makefile(-templates) make clean configure, etc.
+
+`make`: the model is only compiled (make). No make clean etc., thus, can
+resume a started make.
+
+#### Directories
+
+Paths like `bin-dir`, `run-dir`, `forcing-dirs`, `namelist-dirs` are
+arbitrary. Even the `root-dir`, which means, that theoretically a
+different version of `bldsva` or component-models under `root-dir` could
+be used. If this makes sense is questionable (error prone).
+
+## Shell script `setup_tsmp.ksh` ##
+
+### Routines
+
+Most of the routines are identical or have the same purpose as those in
+`build_tsmp.ksh`.
+
+The following will only list significantly different.
+
+#### finalizeSelection()
+
+Additionally to the identical stuff it also calculates some processor
+counts for the models.
+
+#### softSanityCheck()
+
+Additionally to the identical stuff it also tests for multi-instance
+support (is not supported with Oasis3).
+
+#### MAIN()
+
+Starts with determining root and loading defaults. Then handling the
+command line flags. Then doing sanity checks and sourcing machine-script
+and setup-script based on flags. Then starting the interactive session.
+And finalizing the selection afterwards.
+
+Then a loop loops over the number of instances and searches for a
+individual namelist for that instance. Then a sub-run-dir is created for
+each instance. To create the run the `setup_MOD()` interface routine is
+called for every model and executables are copied to the `run-dir`.
+After the loop the run-script is created.
+
+At the end doing some cleanup and logging.
+
+### Feature
+
+#### Layers of defaults and selections
+
+See section [Layers of defaults and
+selections.](#layers-of-defaults-and-selections).
+
+#### Logging and debugging
+
+See section [Logging and Debugging](#logging-and-debugging).
+
+#### Sanity checks
+
+See section [Sanity checks](#sanity-checks).
+
+#### Directories
+
+See section [Directories](#directories)
+
+For creating run-dirs some extra safety provisions were made. An
+experiment-ID (`-I` flag) is appended to the run-dir. This is per
+default the date. Also, if rundirs already exist, a backup is created to
+avoid potential data losses.
+
+#### Multi instance
+
+Running TSMP in multiple instances is supported by splitting the
+`MPI_COMM_WORLD` in sub-communicators inside the models (standalone) or
+in Oasis3-MCT (coupled). Inside the run directory sub-directories are
+created for every instance. But all start the same executable and will
+then `chdir` depending on the rank. The information is given in an
+instance-mapfile which is created in `createRunscript()`.
+
+Every instance is looking for an individual namelist which needs to be
+named like, for example, `coup_oas.tcl_0` for the 0th member. If no such
+namelist is found it will take the base (`coup_oas.tcl`). In this way
+not all component models need namelists for every instance if no
+perturbation is applied.
+
+#### Restarts
+
+The restarts functionality is basically handled in the namelists itself
+in the model-typical way. But two things need to be given to the script
+in order to perform a restart.
+
+Restart files: Every restarted model needs a restart file to start from.
+This must be provided by the flags `-jkl`.
+
+Initial date: For CLM and ParFlow this only regulates the output naming,
+restart files are sufficient for this two. But for Cosmo also the
+`start_hours` is determined by `startDate`-`initDate`.
+
+Performing an automated spinup or chain-jobs needs to be handled by the
+user (example scripts might be available in the future). This basically
+needs a loop over some restart periods and run the setup-script which
+creates a specific setup in every iteration.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,19 +6,57 @@
 Welcome to TSMP documentation!
 ==============================
 
-Irgendein toller Text hier zum hallo sagen...
+.. toctree::
+   :maxdepth: 3
+   :caption: Introduction:
 
-und natürlich auf alles wichtige direkt verlinken...!
+   content/introduction.md
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
    :caption: Getting Started:
    
-   Getting Started <content/gettingstarted>
+   content/gettingstarted.md
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
+   :caption: Installation:
+
+   content/installation.md
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Building and Running:
+
+   content/build_examples.md
+   content/running.md
+   content/setup_examples.md
+
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Developing:
+
+   content/development.md
+   content/best_practices.md
+   content/structure.md
+   content/intf_da.md
+   content/pdaf.md
+   content/debugging.md
+
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Misc:
+
+   content/remotes.md
+   content/branches.md
+   content/misc.md
+   content/jsc.md
+
+.. toctree::
+   :maxdepth: 3
    :caption: Contributing:
    
-   Documentation <content/contributing/documentation>
+   content/contributing/documentation.md
 


### PR DESCRIPTION
Migrate existing TSMP documentation (as it is) from JSC GitLab [TSMP_manual](https://gitlab.jsc.fz-juelich.de/sdlts/tsmp_manual) to TSMP master.  
This PR is intended to consolidate all existing documentation into the official TSMP GitHub repo, so that no other repos are needed.