### PR TITLE
Fix COSMO coupled mode dummy values usage for restart

### DIFF
--- a/bldsva/intf_oas3/cosmo4_21/oas3/receive_fld_2clm.F90
+++ b/bldsva/intf_oas3/cosmo4_21/oas3/receive_fld_2clm.F90
@@ -241,7 +241,7 @@ INTEGER :: cplstep, cplstop   !CPS cpl step
 !   be necessary? cplfreq should come correctly from oasis
 ! FG the bandaid is still needed to initialize the halo. 
 ! Cells inside the domain are getting overwritten in the first coupling.
-   IF (isec <= cplfreq ) THEN
+   IF (isec == 0 ) THEN
      frcv(:,:,jps_taux) =   0._ireals                      !CPS bandaid
      frcv(:,:,jps_tauy) =   0._ireals                      !CPS bandaid 
      frcv(:,:,jps_lat ) =   0._ireals                      !CPS bandaid

--- a/bldsva/intf_oas3/cosmo5_1/oas3/receive_fld_2clm.F90
+++ b/bldsva/intf_oas3/cosmo5_1/oas3/receive_fld_2clm.F90
@@ -250,7 +250,7 @@ INTEGER :: cplstep, cplstop   !CPS cpl step
 !  CPS new values to remove kinks for startup from midnight
 ! FG the bandaid is still needed to initialize the halo. 
 ! Cells inside the domain are getting overwritten in the first coupling.
-   IF (isec <= cplfreq ) THEN
+   IF (isec == 0 ) THEN
      frcv(:,:,jps_taux) =   -0.00009_wp                     !CPS bandaid
      frcv(:,:,jps_tauy) =   -0.00009_wp                      !CPS bandaid 
      frcv(:,:,jps_lat ) =   4._wp                      !CPS bandaid


### PR DESCRIPTION
Currently, dummy values are used for COSMO in coupled mode until the first coupling time step. The dummy values are originally a bandaid for the halo-regions and contain typical values for a night in summer at mid-latitudes. The usage of the dummy values leads to diverging results between a restarted simulation of a coupled simulation with COSMO-CLM(-ParFlow) and an initial simulation. This is unintended, and due to the fix the dummy values will only be written at the initial step (`istep==0`).

The effect of the fix is biggest for restarted simulation with a large coupling time step between COSMO-CLM as well as simulation at noon and/or surface temperature (`tsf >>/<< 287.589 K`)

Caution: This code change will change the results of a restarted simulation. The restarted simulation will not be binary identical compared to an initial simulation, as one would need to read in the oasis fields of the initial run at restart time. 