### PR TITLE
Change ICON-CLM3.5 coupling counter from OASIS to seconds.

### DIFF
--- a/bldsva/intf_oas3/icon2-1/tsmp/mo_nh_stepping.f90
+++ b/bldsva/intf_oas3/icon2-1/tsmp/mo_nh_stepping.f90
@@ -1655,8 +1655,9 @@ MODULE mo_nh_stepping
     !
     nlev = p_patch(1)%nlev
 
-    ! SBr, CHa: coupling counter
-    sim_time_oas = FLOOR(sim_time * 10.)
+    ! coupling counter from tenth of seconds
+!    sim_time_oas = FLOOR(sim_time * 10.)
+    sim_time_oas = NINT(sim_time) ! from seconds
 
     !CALL diagnose_pres_temp (p_metrics, pt_prog, pt_prog_rcf,   &
     !     &                      pt_diag, pt_patch,                 &

--- a/bldsva/intf_oas3/icon2-622/tsmp/mo_nh_stepping.f90
+++ b/bldsva/intf_oas3/icon2-622/tsmp/mo_nh_stepping.f90
@@ -1876,8 +1876,9 @@ MODULE mo_nh_stepping
     !
     nlev = p_patch(1)%nlev
 
-    ! SBr, CHa: coupling counter
-    sim_time_oas = FLOOR(sim_time * 10.)
+    ! coupling counter from tenth of seconds
+!    sim_time_oas = FLOOR(sim_time * 10.)
+    sim_time_oas = NINT(sim_time) ! from seconds
 
     !SPo test timing for restart
     IF(msg_level > 30 ) THEN


### PR DESCRIPTION
Change that the coupling counter of ICON for the coupling expect unit seconds instead of tenth of seconds. 