### PR TITLE
`c_setup_pfl`: adapt condition for copying `coup_oas.tcl` to ensemble runs

### DIFF
--- a/bldsva/setup_tsmp.ksh
+++ b/bldsva/setup_tsmp.ksh
@@ -1134,8 +1134,8 @@ c_setup_eclm(){
 c_setup_pfl(){
 route "${cyellow}>>> c_setup_pfl${cnormal}"
 
-  if [ ! -f "$rundir/coup_oas.tcl" ]; then
-    comment "  $rundir/coup_oas.tcl does not exist, is copied, see c_setup_pfl()"
+  if [ $numInst > 1 ] || [! -f "$rundir/coup_oas.tcl" ]; then
+    comment "  $rundir/coup_oas.tcl does not exist (or for ensemble runs: numInst > 1), is copied, see c_setup_pfl()"
     cp $namelist_pfl $rundir/coup_oas.tcl >> $log_file 2>> $err_file
     check
   fi


### PR DESCRIPTION
Before: Copy `coup_oas.tcl` if it does not exist in `$rundir`

Now: Copy `coup_oas.tcl` if it does not exist in `$rundir` OR if there are multiple ensemble members!