### PR TITLE
common_setup.ksh: define location of static files in single variable

### DIFF
--- a/bldsva/setups/common_setup.ksh
+++ b/bldsva/setups/common_setup.ksh
@@ -1,11 +1,11 @@
 #! /bin/ksh
 
 initSetup(){
-  defaultFDCLM="$rootdir/$static_files/clm"
-  defaultFDCOS="$rootdir/$static_files/cosmo"
-  defaultFDOAS="$rootdir/$static_files/oasis3"
-  defaultFDPFL="$rootdir/$static_files/parflow"
-  defaultFDICON="$rootdir/$static_files/icon"
+  defaultFDCLM="$static_files/clm"
+  defaultFDCOS="$static_files/cosmo"
+  defaultFDOAS="$static_files/oasis3"
+  defaultFDPFL="$static_files/parflow"
+  defaultFDICON="$static_files/icon"
 
   defaultNLCLM=$rootdir/bldsva/setups/$refSetup/lnd.stdin 
   defaultNLCOS=$rootdir/bldsva/setups/$refSetup/lmrun_uc 

--- a/bldsva/setups/cordex/cordex.ksh
+++ b/bldsva/setups/cordex/cordex.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_eur11_eraint_eval_v2/input
+static_files=$rootdir/tsmp_eur11_eraint_eval_v2/input
 
 StartDate="2021-06-24 12"
 InitDate="2021-06-24 12"

--- a/bldsva/setups/ideal1200600/ideal1200600.ksh
+++ b/bldsva/setups/ideal1200600/ideal1200600.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_idealscal/input_1200600
+static_files=$rootdir/tsmp_idealscal/input_1200600
 
 StartDate="2008-05-08 00"
 InitDate="2008-05-08 00"

--- a/bldsva/setups/ideal24001200/ideal24001200.ksh
+++ b/bldsva/setups/ideal24001200/ideal24001200.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_idealscal/input_24001200
+static_files=$rootdir/tsmp_idealscal/input_24001200
 
 StartDate="2008-05-08 00"
 InitDate="2008-05-08 00"

--- a/bldsva/setups/ideal300150/ideal300150.ksh
+++ b/bldsva/setups/ideal300150/ideal300150.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_idealscal/input_300150
+static_files=$rootdir/tsmp_idealscal/input_300150
 
 StartDate="2008-05-08 00"
 InitDate="2008-05-08 00"

--- a/bldsva/setups/ideal600300/ideal600300.ksh
+++ b/bldsva/setups/ideal600300/ideal600300.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_idealscal/input_600300
+static_files=$rootdir/tsmp_idealscal/input_600300
 
 StartDate="2008-05-08 00"
 InitDate="2008-05-08 00"

--- a/bldsva/setups/idealRTD/idealRTD.ksh
+++ b/bldsva/setups/idealRTD/idealRTD.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_idealrtd/input
+static_files=$rootdir/tsmp_idealrtd/input
 
 StartDate="2015-08-07 00"
 InitDate="2015-08-07 00"

--- a/bldsva/setups/idiurnal-cycle/idiurnal-cycle.ksh
+++ b/bldsva/setups/idiurnal-cycle/idiurnal-cycle.ksh
@@ -3,7 +3,7 @@
 source /p/software/$SYSTEMNAME/lmod/lmod/init/ksh
 module load GCC OpenMPI CDO NCO
 
-static_files=tsmp_idiurnal-cycle/input
+static_files=$rootdir/tsmp_idiurnal-cycle/input
 
 defaultFDCLM="$rootdir/$static_files/clm"
 defaultFDCOS="$rootdir/$static_files/cosmo"

--- a/bldsva/setups/nrw/nrw.ksh
+++ b/bldsva/setups/nrw/nrw.ksh
@@ -1,6 +1,6 @@
 #! /bin/ksh
 
-static_files=tsmp_nrw/input
+static_files=$rootdir/tsmp_nrw/input
 
 StartDate="2008-05-08 00"
 InitDate="2008-05-08 00"


### PR DESCRIPTION
additionally: change existing setups, such that `static_files` variable is defined with `$rootdir` prefix.