### PR TITLE
More checks to reduce error print outs and fixes for idealscal and idiurnal-cycle

### DIFF
--- a/bldsva/setups/common_setup.ksh
+++ b/bldsva/setups/common_setup.ksh
@@ -135,33 +135,28 @@ else
         comment "   cd to rundir"
           cd $rundir >> $log_file 2>> $err_file
         check
-
+		if [ -f $forcingdir_pfl/ascii2pfb_slopes.tcl ]; then
         comment "   copy slopes and slope script into rundir"
           cp $forcingdir_pfl/ascii2*.tcl $rundir/ >> $log_file 2>> $err_file
 		check_pfl
           cp $forcingdir_pfl/$slope $rundir >> $log_file 2>> $err_file
 		check_pfl
           chmod u+w $rundir/$slope  $rundir/ascii2*.tcl >> $log_file 2>> $err_file
-
-    comment "   copy initial pressure and script into rundir"
-		  cp $forcingdir_pfl/$inipress $rundir/ >> $log_file 2>> $err_file
-	check_pfl
-	comment "   sed procs into slopescript"
+		comment "   sed procs into slopescript"
           sed "s,lappend auto_path.*,lappend auto_path $bindir/bin," -i $rundir/ascii2pfb_slopes.tcl >> $log_file 2>> $err_file
 	
           sed "s,__nprocx_pfl__,$px_pfl," -i $rundir/ascii2pfb_slopes.tcl >> $log_file 2>> $err_file
 	
           sed "s,__nprocy_pfl__,$py_pfl," -i $rundir/ascii2pfb_slopes.tcl >> $log_file 2>> $err_file
           tclsh ./ascii2pfb_slopes.tcl >> $log_file 2>> $err_file
-	check_pfl	
-	comment "   create sloap pfb with tclsh"
-		  sed "s,lappend auto_path.*,lappend auto_path $bindir/bin," -i $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
-	      sed "s,pfset Process\.Topology\.P.*,pfset Process\.Topology\.P $px_pfl," -i $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
-          sed "s,pfset Process\.Topology\.Q.*,pfset Process\.Topology\.Q $py_pfl," -i $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
-
-          tclsh ./ascii2pfb.tcl >> $log_file 2>> $err_file
-    check_pfl			
-	
+		check_pfl
+		fi
+	if [ -f $forcingdir_pfl/$inipress ]; then
+    comment "   copy initial pressure and script into rundir"
+		  cp $forcingdir_pfl/$inipress $rundir/ >> $log_file 2>> $err_file
+	check_pfl
+	fi
+	if [ -f $forcingdir_pfl/ascii2pfb_SoilInd.tcl ]; then
 	comment "   copy soilind and soilind script into rundir"
           cp $forcingdir_pfl/ascii2pfb_SoilInd.tcl $rundir/ascii2pfb_SoilInd.tcl >> $log_file 2>> $err_file
 	
@@ -182,6 +177,7 @@ else
           sed "s,__nprocy_pfl__,$py_pfl," -i $rundir/ascii2pfb_SoilInd.tcl >> $log_file 2>> $err_file
 	
           sed "s,__pfl_solidinput_filename__,$defaultFDPFL/$pfsolPFL," -i $rundir/coup_oas.tcl >> $log_file 2>> $err_file
+	fi
 	
         tclsh ./coup_oas.tcl >> $log_file 2>> $err_file
     check_pfl

--- a/bldsva/setups/common_setup.ksh
+++ b/bldsva/setups/common_setup.ksh
@@ -155,7 +155,7 @@ else
     comment "   copy initial pressure and script into rundir"
 		  cp $forcingdir_pfl/$inipress $rundir/ >> $log_file 2>> $err_file
 		  if [ -f $forcingdir_pfl/ascii2pfb.tcl ]; then
-		  comment "   create sloap pfb with tclsh"
+		  comment "   distribute initial pressure"
 		  cp $forcingdir_pfl/ascii2pfb.tcl $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
 		  check_pfl
 		  chmod u+w $rundir/rur_ic_press.pfb  $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
@@ -186,10 +186,7 @@ else
           sed "s,__nprocy_pfl__,$py_pfl," -i $rundir/ascii2pfb_SoilInd.tcl >> $log_file 2>> $err_file
 	check_pfl
 	comment "   create soilInd pfb with tclsh"
-        tclsh ./ascii2pfb_SoilInd.tcl >> $log_file 2>> $err_file
-	
-          sed "s,__nprocy_pfl__,$py_pfl," -i $rundir/ascii2pfb_SoilInd.tcl >> $log_file 2>> $err_file
-	
+        tclsh ./ascii2pfb_SoilInd.tcl >> $log_file 2>> $err_file		
           sed "s,__pfl_solidinput_filename__,$defaultFDPFL/$pfsolPFL," -i $rundir/coup_oas.tcl >> $log_file 2>> $err_file
 	fi
 	

--- a/bldsva/setups/common_setup.ksh
+++ b/bldsva/setups/common_setup.ksh
@@ -154,6 +154,20 @@ else
 	if [ -f $forcingdir_pfl/$inipress ]; then
     comment "   copy initial pressure and script into rundir"
 		  cp $forcingdir_pfl/$inipress $rundir/ >> $log_file 2>> $err_file
+		  if [ -f $forcingdir_pfl/ascii2pfb.tcl ]; then
+		  comment "   create sloap pfb with tclsh"
+		  cp $forcingdir_pfl/ascii2pfb.tcl $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
+		  check_pfl
+		  chmod u+w $rundir/rur_ic_press.pfb  $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
+		  check_pfl
+		  sed "s,lappend auto_path.*,lappend auto_path $bindir/bin," -i $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
+		  check_pfl
+	      sed "s,pfset Process\.Topology\.P.*,pfset Process\.Topology\.P $px_pfl," -i $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
+	      check_pfl
+          sed "s,pfset Process\.Topology\.Q.*,pfset Process\.Topology\.Q $py_pfl," -i $rundir/ascii2pfb.tcl >> $log_file 2>> $err_file
+          check_pfl
+          tclsh ./ascii2pfb.tcl >> $log_file 2>> $err_file
+          fi
 	check_pfl
 	fi
 	if [ -f $forcingdir_pfl/ascii2pfb_SoilInd.tcl ]; then

--- a/bldsva/setups/ideal1200600/coup_oas.tcl
+++ b/bldsva/setups/ideal1200600/coup_oas.tcl
@@ -330,4 +330,4 @@ pfset Solver.WriteCLMBinary			        False
 #-----------------------------------------------------------------------------
 #pfrun default_single
 #pfundist default_single
-pfwritedb rurlaf
+pfwritedb ideal

--- a/bldsva/setups/ideal24001200/coup_oas.tcl
+++ b/bldsva/setups/ideal24001200/coup_oas.tcl
@@ -330,4 +330,4 @@ pfset Solver.WriteCLMBinary			        False
 #-----------------------------------------------------------------------------
 #pfrun default_single
 #pfundist default_single
-pfwritedb rurlaf
+pfwritedb ideal

--- a/bldsva/setups/ideal300150/coup_oas.tcl
+++ b/bldsva/setups/ideal300150/coup_oas.tcl
@@ -330,4 +330,4 @@ pfset Solver.WriteCLMBinary			        False
 #-----------------------------------------------------------------------------
 #pfrun default_single
 #pfundist default_single
-pfwritedb rurlaf
+pfwritedb ideal

--- a/bldsva/setups/ideal600300/coup_oas.tcl
+++ b/bldsva/setups/ideal600300/coup_oas.tcl
@@ -330,4 +330,4 @@ pfset Solver.WriteCLMBinary			        False
 #-----------------------------------------------------------------------------
 #pfrun default_single
 #pfundist default_single
-pfwritedb rurlaf
+pfwritedb ideal

--- a/bldsva/setups/idiurnal-cycle/idiurnal-cycle.ksh
+++ b/bldsva/setups/idiurnal-cycle/idiurnal-cycle.ksh
@@ -5,11 +5,11 @@ module load GCC OpenMPI CDO NCO
 
 static_files=$rootdir/tsmp_idiurnal-cycle/input
 
-defaultFDCLM="$rootdir/$static_files/clm"
-defaultFDCOS="$rootdir/$static_files/cosmo"
-defaultFDOAS="$rootdir/$static_files/oasis3"
-defaultFDPFL="$rootdir/$static_files/parflow"
-defaultFDICON="$rootdir/$static_files/icon"
+defaultFDCLM="$static_files/clm"
+defaultFDCOS="$static_files/cosmo"
+defaultFDOAS="$static_files/oasis3"
+defaultFDPFL="$static_files/parflow"
+defaultFDICON="$static_files/icon"
 
 defaultNLICON="$rootdir/bldsva/setups/$refSetup/icon_master.namelist $rootdir/bldsva/setups/$refSetup/NAMELIST_icon"
 defaultICONProc=316


### PR DESCRIPTION
I introduced some if checks to reduce the error print-outs in common_setup.ksh.

Additionally, there were bugs in the idealscal (not matching names) and the idiurnal-cycle (path-issues) setups.