### PR TITLE
Correct remap renaming for idealscal

### DIFF
--- a/bldsva/setups/common_setup.ksh
+++ b/bldsva/setups/common_setup.ksh
@@ -114,11 +114,15 @@ else
       cp $forcingdir_oas/* $rundir >> $log_file 2>> $err_file
     check
     if [[ $withOASMCT == "true" ]] then
-      for x in $rundir/*BILINEA* ;do 
-        comment "   rename oasis3 remapping files" 
-          mv $x $(echo $x | sed "s/BILINEA/BILINEAR/") >> $log_file 2>> $err_file
-        check 
-      done
+      if [ -f "$rundir"/*BILINEAR* ]; then
+        comment "  no renaming of oasis3 remapping files needed" 
+      else
+        for x in $rundir/*BILINEA* ;do 
+          comment "   rename oasis3 remapping files" 
+            mv $x $(echo $x | sed "s/BILINEA/BILINEAR/") >> $log_file 2>> $err_file
+          check 
+        done
+      fi
     fi  
   fi  
 


### PR DESCRIPTION
In the past, remap-files were always provided with the name rmp_gcos_to_gclm_BILINEA.nc. Therefore, the setup added a "R" at the end. The files for ideal1200600, etc. already have the name rmp_gcos_to_gclm_BILINEAR.nc. A check was added to account for that.