### PR TITLE
TSMP-PDAF:  fix  return value type error during parflow compilation

### DIFF
--- a/bldsva/intf_DA/pdaf/tsmp/parflow/parflow_proto.h
+++ b/bldsva/intf_DA/pdaf/tsmp/parflow/parflow_proto.h
@@ -979,8 +979,8 @@ typedef PFModule *(*SaturationOutputStaticInvoke) (char *file_prefix, ProblemDat
 /* problem_saturation.c */
 void Saturation(Vector *phase_saturation, Vector *phase_pressure, Vector *phase_density, double gravity, ProblemData *problem_data, int fcn);
 //>>TSMP-PDAF addition beginning
-PFModule *SaturationGetAlpha(PFModule *this_module);
-PFModule *SaturationGetN(PFModule *this_module);
+Vector *SaturationGetAlpha(PFModule *this_module);
+Vector *SaturationGetN(PFModule *this_module);
 //<<TSMP-PDAF addition end
 PFModule *SaturationInitInstanceXtra(Grid *grid, double *temp_data);
 void SaturationFreeInstanceXtra(void);

--- a/bldsva/intf_DA/pdaf/tsmp/parflow/problem_saturation.c
+++ b/bldsva/intf_DA/pdaf/tsmp/parflow/problem_saturation.c
@@ -661,7 +661,7 @@ void     Saturation(
  * SaturationGetAlpha
  *--------------------------------------------------------------------------*/
 
-PFModule *SaturationGetAlpha(PFModule *this_module)
+Vector *SaturationGetAlpha(PFModule *this_module)
 {
     PublicXtra *public_xtra = (PublicXtra *)PFModulePublicXtra(this_module);
 
@@ -675,7 +675,7 @@ PFModule *SaturationGetAlpha(PFModule *this_module)
  * SaturationGetN
  *--------------------------------------------------------------------------*/
 
-PFModule *SaturationGetN(PFModule *this_module)
+Vector *SaturationGetN(PFModule *this_module)
 {
     PublicXtra *public_xtra = (PublicXtra *)PFModulePublicXtra(this_module);
 

--- a/bldsva/intf_DA/pdaf/tsmp/parflow/solver_richards.c
+++ b/bldsva/intf_DA/pdaf/tsmp/parflow/solver_richards.c
@@ -4057,6 +4057,7 @@ char          filename[2048];
 
 //>>TSMP-PDAF addition beginning
 // Compare to AdvanceRichards() in parflow v3.9.0
+void
 PseudoAdvanceRichards(PFModule * this_module, double start_time,      /* Starting time */
                 double stop_time,       /* Stopping time */
                 PFModule * time_step_control,   /* Use this module to control timestep if supplied */


### PR DESCRIPTION
error: `return value type does not match the function type`

Problem was fixed in TSMP2-PDAF a year ago: https://github.com/HPSCTerrSys/parflow/commit/f5ed22a9068aca4fe745c0918ab3506c51d4b6c2

Another fix adopted from https://github.com/HPSCTerrSys/parflow/commit/5e9bd79b936c38f8c5abfaf82ac84f982112aee1