### PR TITLE
build: `bindir` input (from flag `-B`) applied to rootdir

### DIFF
--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -174,7 +174,7 @@ setSelection(){
 
 finalizeSelection(){
 comment "  create bindir: $bindir"
-  mkdir -p $bindir/libs >> $log_file 2>> $err_file
+  mkdir -p $rootdir/$bindir/libs >> $log_file 2>> $err_file
 check
 
 }


### PR DESCRIPTION
Example: Before this PR, the command

`./build_tsmp.ksh -c clm5-pdaf -m JURECA -O Intel -B
bin/JURECA_clm5-pdaf-debug`

created the `bindir` inside `bldsva`, i.e.

```
$rootdir/bldsva/bin/JURECA_clm5-pdaf-debug
```

After this PR `bindir` is created in the
`$rootdir`. This is how the default-bindirs are placed:

```
$rootdir/bin/JURECA_clm5-pdaf-debug
```

Additionally, it is safer to use an absolute path in `finalizeSelection`.