### PR TITLE
Refactoring the use of `xcoord`, `ycoord`, `zcoord` and corresponding Fortran arrays

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
@@ -41,8 +41,8 @@ SUBROUTINE finalize_pdaf()
 ! !USES:
   USE mod_assimilation, &      ! Variables for assimilation
        ONLY: dim_state_p_count, obs_p, &
-             obs_index_p, xcoord_fortran_g, ycoord_fortran_g, &
-             zcoord_fortran_g, obs_index_l, global_to_local
+             obs_index_p, &
+             obs_index_l, global_to_local
   USE mod_parallel_pdaf, &
        ONLY: local_npes_model, mype_world
 
@@ -68,9 +68,6 @@ SUBROUTINE finalize_pdaf()
   if (allocated(dim_state_p_count)) deallocate (dim_state_p_count)
   ! M.Pondkule: deallocating variables used in data assimilation
   ! with letkf filter
-  IF (ALLOCATED(xcoord_fortran_g)) DEALLOCATE(xcoord_fortran_g)
-  IF (ALLOCATED(ycoord_fortran_g)) DEALLOCATE(ycoord_fortran_g)
-  IF (ALLOCATED(zcoord_fortran_g)) DEALLOCATE(zcoord_fortran_g)
   IF (ALLOCATED(obs_index_l)) DEALLOCATE(obs_index_l)
   IF (ALLOCATED(global_to_local)) DEALLOCATE(global_to_local)
 

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -87,12 +87,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
        clmobs_lon, clmobs_lat, clmobs_layer, clmobs_dr, clm_obserr
   use mod_tsmp, &
       only: idx_map_subvec2state_fortran, tag_model_parflow, enkf_subvecsize, &
-#ifndef CLMSA
-#ifndef OBS_ONLY_CLM
-      xcoord, ycoord, zcoord, xcoord_fortran, ycoord_fortran, &
-      zcoord_fortran, &
-#endif
-#endif
       tag_model_clm, point_obs, model
 
 #ifndef PARFLOW_STAND_ALONE
@@ -651,18 +645,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   ! Gather array of local observation dimensions 
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
-
-#ifndef CLMSA
-#ifndef OBS_ONLY_CLM
-!!#if (defined PARFLOW_STAND_ALONE || defined COUP_OAS_PFL)
-  IF (model == tag_model_parflow) THEN
-     !print *, "Parflow: converting xcoord to fortran"
-     call C_F_POINTER(xcoord, xcoord_fortran, [enkf_subvecsize])
-     call C_F_POINTER(ycoord, ycoord_fortran, [enkf_subvecsize])
-     call C_F_POINTER(zcoord, zcoord_fortran, [enkf_subvecsize])
-  ENDIF
-#endif
-#endif
 
   !  clean up the temp data from nc file
   ! ------------------------------------

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_l_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_l_pdaf.F90
@@ -91,6 +91,7 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
   !  INTEGER :: idx, ix, iy, ix1, iy1
   REAL :: dist ! Distance between observation and analysis domain
   LOGICAL, ALLOCATABLE :: log_var_id(:) ! logical variable ID for setting location observation vector using remote sensing data
+  INTEGER  :: domain_p_coord   ! Current local analysis domain for coord arrays
 
   !kuw
   integer :: dx,dy, max_var_id, ierror
@@ -112,6 +113,17 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
      call C_F_POINTER(ycoord, ycoord_fortran, [enkf_subvecsize])
      call C_F_POINTER(zcoord, zcoord_fortran, [enkf_subvecsize])
   ENDIF
+
+  ! Index for local analysis domain `domain_p` in coordinate array
+  ! that only spans `enkf_subvecsize`.
+  !
+  ! Necessary condition: `domain_p` is initialized as an index of the
+  ! process-local state dimension in `init_n_domains_pdaf`
+  !
+  ! Necessary condition II: the full state vector consists of sections
+  ! of size `enkf_subvecsize`, where each section corresponds to a
+  ! single coordinate array.
+  domain_p_coord = MODULO(domain_p, enkf_subvecsize)
 #endif
 #endif
 
@@ -194,16 +206,16 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
            i = (m-1)* dim_ny + k
            do j = 1, max_var_id
               if(log_var_id(j) .and. var_id_obs_nc(k,m) == j) then
-                 dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p))-1)
-                 dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p))-1)
+                 dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p_coord))-1)
+                 dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p_coord))-1)
                  dist = sqrt(real(dx)**2 + real(dy)**2)
                  !obsdist(i) = dist
                  if (dist <= real(cradius) .AND. dist > 0) then
                     dim_obs_l = dim_obs_l + 1
                     obsind(i) = 1
                     log_var_id(j) = .FALSE.
-                    dx = abs(ix_var_id(j) - int(xcoord_fortran(domain_p))-1)
-                    dy = abs(iy_var_id(j) - int(ycoord_fortran(domain_p))-1)
+                    dx = abs(ix_var_id(j) - int(xcoord_fortran(domain_p_coord))-1)
+                    dy = abs(iy_var_id(j) - int(ycoord_fortran(domain_p_coord))-1)
                     obsdist(i) = sqrt(real(dx)**2 + real(dy)**2)
                  else if(dist == 0) then
                     dim_obs_l = dim_obs_l + 1
@@ -217,8 +229,8 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
      end do
   else   
         do i = 1,dim_obs
-           dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p))-1)
-           dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p))-1)
+           dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p_coord))-1)
+           dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p_coord))-1)
            dist = sqrt(real(dx)**2 + real(dy)**2)
            obsdist(i) = dist
            if (dist <= real(cradius)) then
@@ -242,16 +254,16 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
            i = (m-1)* dim_ny + k
            do j = 1, max_var_id
               if(log_var_id(j) .and. var_id_obs_nc(k,m) == j) then
-                 dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p))-1)
-                 dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p))-1)
+                 dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p_coord))-1)
+                 dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p_coord))-1)
                  dist = sqrt(real(dx)**2 + real(dy)**2)
                  !obsdist(i) = dist
                  if (dist <= real(cradius) .AND. dist > 0) then
                     dim_obs_l = dim_obs_l + 1
                     obsind(i) = 1
                     log_var_id(j) = .FALSE.
-                    dx = abs(ix_var_id(j) - int(xcoord_fortran(domain_p))-1)
-                    dy = abs(iy_var_id(j) - int(ycoord_fortran(domain_p))-1)
+                    dx = abs(ix_var_id(j) - int(xcoord_fortran(domain_p_coord))-1)
+                    dy = abs(iy_var_id(j) - int(ycoord_fortran(domain_p_coord))-1)
                     obsdist(i) = sqrt(real(dx)**2 + real(dy)**2)
                  else if(dist == 0) then
                     dim_obs_l = dim_obs_l + 1
@@ -313,8 +325,8 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
   else   
      if(model == tag_model_parflow) THEN
         do i = 1,dim_obs
-           dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p))-1)
-           dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p))-1)
+           dx = abs(x_idx_obs_nc(i) - int(xcoord_fortran(domain_p_coord))-1)
+           dy = abs(y_idx_obs_nc(i) - int(ycoord_fortran(domain_p_coord))-1)
            dist = sqrt(real(dx)**2 + real(dy)**2)
            obsdist(i) = dist
            if (dist <= real(cradius)) then

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_l_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_l_pdaf.F90
@@ -52,7 +52,7 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
        ONLY: mype_filter, npes_filter, comm_filter
   USE mod_assimilation, &
        ONLY: cradius, obs_index_l, dim_obs, obs_p, distance, obs_index_p, &
-       dim_state, xcoord_fortran_g, ycoord_fortran_g, zcoord_fortran_g, dim_obs_p, &
+       dim_state, dim_obs_p, &
        longxy, latixy, longxy_obs, latixy_obs,  maxlon, minlon, maxlat, minlat, &
        maxix, minix, maxiy, miniy, lon_var_id, ix_var_id, lat_var_id, iy_var_id  
   USE mod_read_obs, &

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_l_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_l_pdaf.F90
@@ -64,11 +64,13 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
        tag_model_clm, point_obs, model
 #else
   ONLY: idx_map_subvec2state_fortran, tag_model_parflow, enkf_subvecsize, &
-       tag_model_clm, nx_glob, ny_glob, nz_glob, xcoord_fortran, ycoord_fortran, &
-       zcoord_fortran, point_obs, model
+       tag_model_clm, nx_glob, ny_glob, nz_glob, &
+       xcoord, ycoord, zcoord, &
+       xcoord_fortran, ycoord_fortran, zcoord_fortran, &
+       point_obs, model
 #endif
 
-  USE, INTRINSIC :: iso_c_binding
+  USE, INTRINSIC :: iso_c_binding, ONLY: C_F_POINTER
 
   IMPLICIT NONE
 
@@ -99,6 +101,20 @@ SUBROUTINE init_dim_obs_l_pdaf(domain_p, step, dim_obs_f, dim_obs_l)
   ! **********************************************
   ! *** Initialize local observation dimension ***
   ! **********************************************
+
+  ! Setting fortran pointer to ParFlow-coordinate arrays
+#ifndef CLMSA
+#ifndef OBS_ONLY_CLM
+!!#if (defined PARFLOW_STAND_ALONE || defined COUP_OAS_PFL)
+  IF (model == tag_model_parflow) THEN
+     !print *, "Parflow: converting xcoord to fortran"
+     call C_F_POINTER(xcoord, xcoord_fortran, [enkf_subvecsize])
+     call C_F_POINTER(ycoord, ycoord_fortran, [enkf_subvecsize])
+     call C_F_POINTER(zcoord, zcoord_fortran, [enkf_subvecsize])
+  ENDIF
+#endif
+#endif
+
   ! Count observations within cradius
 #ifdef CLMSA 
   obsind    = 0

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -95,12 +95,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   use mod_tsmp, &
       only: idx_map_subvec2state_fortran, tag_model_parflow, enkf_subvecsize, &
       nx_glob, ny_glob, nz_glob, crns_flag, da_print_obs_index, &
-#ifndef CLMSA
-#ifndef OBS_ONLY_CLM
-      xcoord, ycoord, zcoord, xcoord_fortran, ycoord_fortran, &
-      zcoord_fortran, &
-#endif
-#endif
       tag_model_clm, point_obs, obs_interp_switch, is_dampfac_state_time_dependent, &
       dampfac_state_time_dependent, is_dampfac_param_time_dependent, dampfac_param_time_dependent, model
 
@@ -957,18 +951,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   ! Gather array of local observation dimensions 
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
-
-#ifndef CLMSA
-#ifndef OBS_ONLY_CLM
-!!#if (defined PARFLOW_STAND_ALONE || defined COUP_OAS_PFL)
-  IF (model == tag_model_parflow) THEN
-     !print *, "Parflow: converting xcoord to fortran"
-     call C_F_POINTER(xcoord, xcoord_fortran, [enkf_subvecsize])
-     call C_F_POINTER(ycoord, ycoord_fortran, [enkf_subvecsize])
-     call C_F_POINTER(zcoord, zcoord_fortran, [enkf_subvecsize])
-  ENDIF
-#endif
-#endif
 
   !  clean up the temp data from nc file
   ! ------------------------------------

--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -53,7 +53,7 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
           model
 #endif
 
-  USE, INTRINSIC :: iso_c_binding
+  USE, INTRINSIC :: iso_c_binding, ONLY: C_F_POINTER
 
   IMPLICIT NONE
 

--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -77,6 +77,7 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
 #if defined CLMSA
   INTEGER :: dim_l, ncellxy,k
 #endif
+  INTEGER :: icoord
 
 ! **********************
 ! *** INITIALIZATION ***
@@ -115,21 +116,23 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
 
 #ifndef CLMSA
   IF(model==tag_model_parflow)THEN
-!hcp enkf_subvecsize is the number of grid cells,
-!which is the size of state vector only if soil moisture
-!or pressure is the entire state vector, which is not true
-!when other parameters are also included in the state vector
-!in which the size of x/ycoord is NOT enkf_subvecsize.
-    call C_F_POINTER(xcoord,xcoord_fortran,[dim_state]) ![enkf_subvecsize])
-    call C_F_POINTER(ycoord,ycoord_fortran,[dim_state]) ![enkf_subvecsize])
-    call C_F_POINTER(zcoord,zcoord_fortran,[dim_state]) ![enkf_subvecsize])
+    call C_F_POINTER(xcoord,xcoord_fortran,[enkf_subvecsize])
+    call C_F_POINTER(ycoord,ycoord_fortran,[enkf_subvecsize])
+    call C_F_POINTER(zcoord,zcoord_fortran,[enkf_subvecsize])
 
     ! localize HP
     DO j = 1, dim_obs
        DO i = 1, dim_state
-    
-         dx = abs(x_idx_obs_nc(obs_nc2pdaf(j)) - int(xcoord_fortran(i))-1)
-         dy = abs(y_idx_obs_nc(obs_nc2pdaf(j)) - int(ycoord_fortran(i))-1)
+
+         ! Index in coordinate array only spans `enkf_subvecsize`.
+         !
+         ! Necessary condition: the full state vector consists of
+         ! sections of size `enkf_subvecsize`, where each section
+         ! corresponds to a single coordinate array.
+         icoord = modulo(i,enkf_subvecsize)
+
+         dx = abs(x_idx_obs_nc(obs_nc2pdaf(j)) - int(xcoord_fortran(icoord))-1)
+         dy = abs(y_idx_obs_nc(obs_nc2pdaf(j)) - int(ycoord_fortran(icoord))-1)
          distance = sqrt(real(dx)**2 + real(dy)**2)
     
          ! Compute weight
@@ -170,9 +173,6 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
    call init_clm_l_size(dim_l)
 
    IF(model==tag_model_clm)THEN
-!    call C_F_POINTER(xcoord,xcoord_fortran,[enkf_subvecsize])
-!    call C_F_POINTER(ycoord,ycoord_fortran,[enkf_subvecsize])
-!    call C_F_POINTER(zcoord,zcoord_fortran,[enkf_subvecsize])
 
     ! localize HP
     ! ncellxy=dim_state/dim_l

--- a/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
@@ -82,9 +82,6 @@ MODULE mod_assimilation
   !end hcp  
   REAL, ALLOCATABLE :: clm_obserr_p(:)    ! Vector holding  observation errors for CLM run at each PE-local domain  
   REAL, ALLOCATABLE :: distance(:)        ! Localization distance
-  REAL, ALLOCATABLE :: xcoord_fortran_g(:), & ! Global coordinates for the domain are stored,
-                       ycoord_fortran_g(:), & ! been gathered from local domains. used when 
-                       zcoord_fortran_g(:)    ! local filter analysis is selected. 
   INTEGER, ALLOCATABLE :: global_to_local(:)  ! Vector to map global index to local domain index
   INTEGER, ALLOCATABLE :: longxy(:), latixy(:), longxy_obs(:), latixy_obs(:) ! longitude and latitude of grid cells and observation cells
   INTEGER, ALLOCATABLE :: longxy_obs_floor(:), latixy_obs_floor(:) ! indices of grid cells with smaller lon/lat than observation location

--- a/bldsva/intf_DA/pdaf/framework/mod_tsmp.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_tsmp.F90
@@ -37,8 +37,12 @@ module mod_tsmp
     integer(c_int), bind(c)  :: crns_flag
     integer(c_int), bind(c)  :: da_print_obs_index
     type(c_ptr), bind(c)     :: pf_statevec
-    type(c_ptr), bind(c)     :: xcoord, ycoord, zcoord
-    real(c_double), pointer  :: xcoord_fortran(:), ycoord_fortran(:), zcoord_fortran(:)
+    type(c_ptr), bind(c)     :: xcoord
+    type(c_ptr), bind(c)     :: ycoord
+    type(c_ptr), bind(c)     :: zcoord
+    real(c_double), pointer  :: xcoord_fortran(:) ! Global coordinates for the domain are stored,
+    real(c_double), pointer  :: ycoord_fortran(:) ! been gathered from local domains. used when
+    real(c_double), pointer  :: zcoord_fortran(:) ! local filter analysis is selected.
     real(c_double), pointer  :: pf_statevec_fortran(:)
     real(c_double), bind(c)  :: da_crns_depth_tol
     type(c_ptr), bind(c)     :: idx_map_subvec2state

--- a/bldsva/intf_DA/pdaf/model/parflow/enkf_parflow.c
+++ b/bldsva/intf_DA/pdaf/model/parflow/enkf_parflow.c
@@ -52,26 +52,19 @@ void init_idx_map_subvec2state(Vector *pf_vector) {
 	Grid *grid = VectorGrid(pf_vector);
 
 	int sg;
-	double *tmpdat;
 
 	// allocate x, y z coords
 	int num = enkf_subvecsize;
 
-   // hcp param update conditional statement
-   // we need to indicate the physical coordinates
-   // of the parameter (K_sat) in the x/ycoord if
-   // it is included in the state vector for
-   // localization purposes.
+	xcoord = (double *) malloc(enkf_subvecsize * sizeof(double));
+	ycoord = (double *) malloc(enkf_subvecsize * sizeof(double));
+	zcoord = (double *) malloc(enkf_subvecsize * sizeof(double));
+
 	/* pf_paramupdate == 2 could need updates, see line 447 */
 	if( pf_paramupdate == 1 || pf_paramupdate == 2 || pf_paramupdate == 3 ) num *= 2;
 	if( pf_paramupdate == 4 || pf_paramupdate == 5 ) num *= 3;
 	if( pf_paramupdate == 6 || pf_paramupdate == 7 ) num *= 4;
 	if( pf_paramupdate == 8 ) num *= 5;
-
-	xcoord = (double *) malloc(num * sizeof(double));
-	ycoord = (double *) malloc(num * sizeof(double));
-	zcoord = (double *) malloc(num * sizeof(double));
-	//tmpdat = (double *) malloc(enkf_subvecsize * sizeof(double));
 
 	// copy dz_mult to double
 	ProblemData * problem_data = GetProblemDataRichards(solver);
@@ -131,68 +124,11 @@ void init_idx_map_subvec2state(Vector *pf_vector) {
 					ycoord[counter] =   j;
 					zcoord[counter] =   k;
 					//zcoord[counter] = SubgridZ(subgrid) + k * SubgridDZ(subgrid)*values[k];
-                                        //tmpdat[counter] = (double)idx_map_subvec2state[counter];
 					counter++;
 
 				}
 			}
 		}
-
-      //  hcp paramupdate
-      //  here we indicate the physical coordinates of the
-      //  parameters according to their addresses in the
-      //  state vector.
-      /* pf_paramupdate == 2 could need updates, see line 447 */
-      if( pf_paramupdate == 1 || pf_paramupdate == 2 || pf_paramupdate == 3 )
-      {
-         for( i = 0; i < enkf_subvecsize; i++ ) {
-            xcoord[enkf_subvecsize + i] = xcoord[i];
-            ycoord[enkf_subvecsize + i] = ycoord[i];
-            zcoord[enkf_subvecsize + i] = zcoord[i];
-         };
-      }
-      if( pf_paramupdate == 4 || pf_paramupdate == 5 )
-      {
-         for( i = 0; i < enkf_subvecsize; i++ ) {
-            xcoord[enkf_subvecsize + i] = xcoord[i];
-            ycoord[enkf_subvecsize + i] = ycoord[i];
-            zcoord[enkf_subvecsize + i] = zcoord[i];
-            xcoord[2*enkf_subvecsize + i] = xcoord[i];
-            ycoord[2*enkf_subvecsize + i] = ycoord[i];
-            zcoord[2*enkf_subvecsize + i] = zcoord[i];
-         };
-      }
-      if( pf_paramupdate == 6 || pf_paramupdate == 7 )
-      {
-         for( i = 0; i < enkf_subvecsize; i++ ) {
-            xcoord[enkf_subvecsize + i] = xcoord[i];
-            ycoord[enkf_subvecsize + i] = ycoord[i];
-            zcoord[enkf_subvecsize + i] = zcoord[i];
-            xcoord[2*enkf_subvecsize + i] = xcoord[i];
-            ycoord[2*enkf_subvecsize + i] = ycoord[i];
-            zcoord[2*enkf_subvecsize + i] = zcoord[i];
-            xcoord[3*enkf_subvecsize + i] = xcoord[i];
-            ycoord[3*enkf_subvecsize + i] = ycoord[i];
-            zcoord[3*enkf_subvecsize + i] = zcoord[i];
-         };
-      }
-      if( pf_paramupdate == 8 )
-      {
-         for( i = 0; i < enkf_subvecsize; i++ ) {
-            xcoord[enkf_subvecsize + i] = xcoord[i];
-            ycoord[enkf_subvecsize + i] = ycoord[i];
-            zcoord[enkf_subvecsize + i] = zcoord[i];
-            xcoord[2*enkf_subvecsize + i] = xcoord[i];
-            ycoord[2*enkf_subvecsize + i] = ycoord[i];
-            zcoord[2*enkf_subvecsize + i] = zcoord[i];
-            xcoord[3*enkf_subvecsize + i] = xcoord[i];
-            ycoord[3*enkf_subvecsize + i] = ycoord[i];
-            zcoord[3*enkf_subvecsize + i] = zcoord[i];
-            xcoord[4*enkf_subvecsize + i] = xcoord[i];
-            ycoord[4*enkf_subvecsize + i] = ycoord[i];
-            zcoord[4*enkf_subvecsize + i] = zcoord[i];
-         };
-      }
 
       /* store local dimensions for later use */
     nx_local = nx;
@@ -220,14 +156,6 @@ void init_idx_map_subvec2state(Vector *pf_vector) {
 	}
 #endif
 
-    //free(xcoord);
-    //free(ycoord);
-    //free(zcoord);
-    //enkf_printvec("info","index", tmpdat);
-    //enkf_printvec("info","xcoord", xcoord);
-    //enkf_printvec("info","ycoord", ycoord);
-    //enkf_printvec("info","zcoord", zcoord);
-    //free(tmpdat);
 }
 
 void PseudoAdvanceRichards(PFModule *this_module, double start_time, /* Starting time */

--- a/bldsva/intf_DA/pdaf/model/parflow/enkf_parflow.h
+++ b/bldsva/intf_DA/pdaf/model/parflow/enkf_parflow.h
@@ -58,7 +58,9 @@ GLOBAL double *subvec_permy;
 GLOBAL double *subvec_permz;
 GLOBAL double *arr_aniso_perm_yy;
 GLOBAL double *arr_aniso_perm_zz;
-GLOBAL double * xcoord, * ycoord, * zcoord;
+GLOBAL double * xcoord;
+GLOBAL double * ycoord;
+GLOBAL double * zcoord;
 /* hcp CRNS begins */
 //GLOBAL double *subvec_Kind;    //hcp
 GLOBAL double *soilay;  //hcp soil layers


### PR DESCRIPTION
### remove the following unused coordinate arrays

- `xcoord_fortran_g`
- `ycoord_fortran_g`
- `zcoord_fortran_g`

### refactor use of `xcoord_fortran`, `ycoord_fortran`, `zcoord_fortran` I

Move assignment of the Fortran pointer `xcoord_fortran`,
`ycoord_fortran`, `zcoord_fortran` from the global observation
initialisation routines (`init_dim_obs_pdaf` and
`init_dim_obs_f_pdaf`) to the routines, where they are used:

- `localize_covar`: LEnKF covariance localization
- `init_dim_obs_l_pdaf`: LETKF/LESTKF setting local
   observation vector of the local analysis domain

### refactor `xcoord_fortran`, `ycoord_fortran`, `zcoord_fortran` II

Change size of `xcoord`, `ycoord`, `zcoord` to `enkf_subvecsize`,
i.e. only the size of one (grid-sized) subvector of the entire state
vector. (`enkf_parflow.c`).

For usage of the coordinate arrays in `init_dim_obs_l_pdaf` and
`localize_covar_pdaf`, the indices for the coordinate array have to
use `modulo` to project the general state vector index onto the first
subvector.

Prerequisite: the full state vector consists of sections of size
`enkf_subvecsize`, where each section corresponds to a single
coordinate array. This prerequisite was also necessary  before this PR.