### PR TITLE
Refactor use of  `local_dims_obs` array

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
@@ -42,7 +42,9 @@ SUBROUTINE finalize_pdaf()
   USE mod_assimilation, &      ! Variables for assimilation
        ONLY: dim_state_p_count, obs_p, &
              obs_index_p, &
-             obs_index_l, global_to_local
+             obs_index_l, global_to_local, &
+             local_dims_obs, &
+             local_disp_obs
   USE mod_parallel_pdaf, &
        ONLY: local_npes_model, mype_world
 

--- a/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
@@ -70,6 +70,7 @@ SUBROUTINE finalize_pdaf()
   ! with letkf filter
   IF (ALLOCATED(obs_index_l)) DEALLOCATE(obs_index_l)
   IF (ALLOCATED(global_to_local)) DEALLOCATE(global_to_local)
+  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
 
 ! *** Finalize parallel MPI region - if not done by model ***
 !  CALL finalize_parallel()

--- a/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/finalize_pdaf.F90
@@ -71,6 +71,7 @@ SUBROUTINE finalize_pdaf()
   IF (ALLOCATED(obs_index_l)) DEALLOCATE(obs_index_l)
   IF (ALLOCATED(global_to_local)) DEALLOCATE(global_to_local)
   IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
+  IF (ALLOCATED(local_disp_obs)) DEALLOCATE(local_disp_obs)
 
 ! *** Finalize parallel MPI region - if not done by model ***
 !  CALL finalize_parallel()

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -129,7 +129,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   INTEGER :: m,l          ! Counters
   logical :: is_multi_observation_files
   character (len = 110) :: current_observation_filename
-  integer,allocatable :: local_dis(:),local_dim(:)
+  integer,allocatable :: local_dis(:)
 
 #ifndef PARFLOW_STAND_ALONE
 #ifndef OBS_ONLY_PARFLOW
@@ -410,14 +410,13 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
+  ! Set array local_dis (number of observations before process) from
+  ! local observation dimensions
   allocate(local_dis(npes_filter))
-  allocate(local_dim(npes_filter))
-  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dim, 1, MPI_INTEGER, comm_filter, ierror)
   local_dis(1) = 0
   do i = 2, npes_filter
-     local_dis(i) = local_dis(i-1) + local_dim(i-1)
+     local_dis(i) = local_dis(i-1) + local_dims_obs(i-1)
   end do
-  deallocate(local_dim)
 
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -399,6 +399,17 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
     call abort_parallel()
   end if
 
+  !  Gather local dim obs in array
+  ! ------------------------------
+
+  ! allocate array of local observation dimensions with total PEs
+  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
+  ALLOCATE(local_dims_obs(npes_filter))
+
+  ! Gather array of local observation dimensions
+  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
+       comm_filter, ierror)
+
   allocate(local_dis(npes_filter))
   allocate(local_dim(npes_filter))
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dim, 1, MPI_INTEGER, comm_filter, ierror)
@@ -411,17 +422,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis
   end if
-
-  !  Gather local dim obs in array
-  ! ------------------------------
-
-  ! allocate array of local observation dimensions with total PEs
-  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
-  ALLOCATE(local_dims_obs(npes_filter))
-
-  ! Gather array of local observation dimensions
-  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
-       comm_filter, ierror)
 
   ! Write process-local observation arrays
   ! --------------------------------------

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -65,6 +65,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
        pressure_obserr_p, clm_obserr_p, &
        obs_nc2pdaf, &
        local_dims_obs, &
+       local_disp_obs, &
        dim_obs_p, &
        obs_id_p, &
 #ifndef PARFLOW_STAND_ALONE
@@ -129,7 +130,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   INTEGER :: m,l          ! Counters
   logical :: is_multi_observation_files
   character (len = 110) :: current_observation_filename
-  integer,allocatable :: local_disp_obs(:)
 
 #ifndef PARFLOW_STAND_ALONE
 #ifndef OBS_ONLY_PARFLOW
@@ -410,9 +410,9 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
-  ! Set array local_disp_obs (number of observations before process) from
-  ! local observation dimensions
-  allocate(local_disp_obs(npes_filter))
+  ! Set observation displacement array  local_disp_obs
+  IF (ALLOCATED(local_disp_obs)) DEALLOCATE(local_disp_obs)
+  ALLOCATE(local_disp_obs(npes_filter))
   local_disp_obs(1) = 0
   do i = 2, npes_filter
      local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)
@@ -651,7 +651,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
   !  clean up the temp data from nc file
   ! ------------------------------------
-  deallocate(local_disp_obs)
   call clean_obs_nc()
 
 END SUBROUTINE init_dim_obs_f_pdaf

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -399,10 +399,10 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
     call abort_parallel()
   end if
 
-  !  Gather local dim obs in array
-  ! ------------------------------
+  !  Gather local observation dimensions and displacements in arrays
+  ! ----------------------------------------------------------------
 
-  ! allocate array of local observation dimensions with total PEs
+  ! Allocate array of local observation dimensions
   IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
   ALLOCATE(local_dims_obs(npes_filter))
 
@@ -410,9 +410,11 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
-  ! Set observation displacement array  local_disp_obs
+  ! Allocate observation displacement array  local_disp_obs
   IF (ALLOCATED(local_disp_obs)) DEALLOCATE(local_disp_obs)
   ALLOCATE(local_disp_obs(npes_filter))
+
+  ! Set observation displacement array  local_disp_obs
   local_disp_obs(1) = 0
   do i = 2, npes_filter
      local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -418,6 +418,17 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis
   end if
 
+  !  Gather local dim obs in array
+  ! ------------------------------
+
+  ! allocate array of local observation dimensions with total PEs
+  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
+  ALLOCATE(local_dims_obs(npes_filter))
+
+  ! Gather array of local observation dimensions
+  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
+       comm_filter, ierror)
+
   ! Write process-local observation arrays
   ! --------------------------------------
   ! allocate index for mapping between observations in nc input and
@@ -643,14 +654,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_nc2pdaf=", obs_nc2pdaf
   end if
-
-  ! allocate array of local observation dimensions with total PEs
-  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
-  ALLOCATE(local_dims_obs(npes_filter))
-
-  ! Gather array of local observation dimensions 
-  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
-       comm_filter, ierror)
 
 #ifndef CLMSA
 #ifndef OBS_ONLY_CLM

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -129,7 +129,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   INTEGER :: m,l          ! Counters
   logical :: is_multi_observation_files
   character (len = 110) :: current_observation_filename
-  integer,allocatable :: local_dis(:)
+  integer,allocatable :: local_disp_obs(:)
 
 #ifndef PARFLOW_STAND_ALONE
 #ifndef OBS_ONLY_PARFLOW
@@ -410,16 +410,16 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
-  ! Set array local_dis (number of observations before process) from
+  ! Set array local_disp_obs (number of observations before process) from
   ! local observation dimensions
-  allocate(local_dis(npes_filter))
-  local_dis(1) = 0
+  allocate(local_disp_obs(npes_filter))
+  local_disp_obs(1) = 0
   do i = 2, npes_filter
-     local_dis(i) = local_dis(i-1) + local_dims_obs(i-1)
+     local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)
   end do
 
   if (mype_filter==0 .and. screen > 2) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_disp_obs=", local_disp_obs
   end if
 
   ! Write process-local observation arrays
@@ -435,8 +435,8 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   ! count = 1
   ! mype_filter = 0
   ! 
-  ! obs_nc2pdaf(local_dis(mype_filter+1)+count) = i
-  !-> obs_nc2pdaf(local_dis(1)+1) = 2
+  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
+  !-> obs_nc2pdaf(local_disp_obs(1)+1) = 2
   !-> obs_nc2pdaf(1) = 2
 
   IF (ALLOCATED(obs)) DEALLOCATE(obs)
@@ -537,7 +537,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
               obs_index_p(count) = j
               obs_p(count) = pressure_obs(i)
               if(multierr.eq.1) pressure_obserr_p(count) = pressure_obserr(i)
-              obs_nc2pdaf(local_dis(mype_filter+1)+count) = i
+              obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
               count = count + 1
            end if
         end do
@@ -632,7 +632,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
               !write(*,*) 'obs_index_p(',count,') is',obs_index_p(count)
               obs_p(count) = clm_obs(i)
               if(multierr.eq.1) clm_obserr_p(count) = clm_obserr(i)
-              obs_nc2pdaf(local_dis(mype_filter+1)+count) = i
+              obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
               count = count + 1
            end if
            k = k + 1
@@ -651,7 +651,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
   !  clean up the temp data from nc file
   ! ------------------------------------
-  deallocate(local_dis)
+  deallocate(local_disp_obs)
   call clean_obs_nc()
 
 END SUBROUTINE init_dim_obs_f_pdaf

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -63,6 +63,7 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
        pressure_obserr_p, clm_obserr_p, &
        obs_nc2pdaf, &
        local_dims_obs, &
+       local_disp_obs, &
        ! dim_obs_p, &
        obs_id_p, &
 #ifndef PARFLOW_STAND_ALONE
@@ -151,7 +152,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   INTEGER :: idx         ! Computed Index
   logical :: is_multi_observation_files
   character (len = 110) :: current_observation_filename
-  integer,allocatable :: local_disp_obs(:)
   integer :: k_count !,nsc !hcp
   real    :: sum_interp_weights
 
@@ -523,9 +523,9 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
-  ! Set array local_disp_obs (number of observations before process) from
-  ! local observation dimensions
-  allocate(local_disp_obs(npes_filter))
+  ! Set observation displacement array local_disp_obs
+  IF (ALLOCATED(local_disp_obs)) DEALLOCATE(local_disp_obs)
+  ALLOCATE(local_disp_obs(npes_filter))
   local_disp_obs(1) = 0
   do i = 2, npes_filter
      local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)
@@ -957,7 +957,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
 
   !  clean up the temp data from nc file
   ! ------------------------------------
-  deallocate(local_disp_obs)
   call clean_obs_nc()
 
 END SUBROUTINE init_dim_obs_pdaf

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -512,10 +512,10 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
     call abort_parallel()
   end if
 
-  !  Gather local dim obs in array
-  ! ------------------------------
+  !  Gather local observation dimensions and displacements in arrays
+  ! ----------------------------------------------------------------
 
-  ! allocate array of local observation dimensions with total PEs
+  ! Allocate array of local observation dimensions
   IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
   ALLOCATE(local_dims_obs(npes_filter))
 
@@ -523,9 +523,11 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
-  ! Set observation displacement array local_disp_obs
+  ! Allocate observation displacement array local_disp_obs
   IF (ALLOCATED(local_disp_obs)) DEALLOCATE(local_disp_obs)
   ALLOCATE(local_disp_obs(npes_filter))
+
+  ! Set observation displacement array local_disp_obs
   local_disp_obs(1) = 0
   do i = 2, npes_filter
      local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -151,7 +151,7 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   INTEGER :: idx         ! Computed Index
   logical :: is_multi_observation_files
   character (len = 110) :: current_observation_filename
-  integer,allocatable :: local_dis(:)
+  integer,allocatable :: local_disp_obs(:)
   integer :: k_count !,nsc !hcp
   real    :: sum_interp_weights
 
@@ -523,16 +523,16 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
-  ! Set array local_dis (number of observations before process) from
+  ! Set array local_disp_obs (number of observations before process) from
   ! local observation dimensions
-  allocate(local_dis(npes_filter))
-  local_dis(1) = 0
+  allocate(local_disp_obs(npes_filter))
+  local_disp_obs(1) = 0
   do i = 2, npes_filter
-     local_dis(i) = local_dis(i-1) + local_dims_obs(i-1)
+     local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)
   end do
 
   if (mype_filter==0 .and. screen > 2) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_disp_obs=", local_disp_obs
   end if
 
   ! Write process-local observation arrays
@@ -548,8 +548,8 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   ! count = 1
   ! mype_filter = 0
   ! 
-  ! obs_nc2pdaf(local_dis(mype_filter+1)+count) = i
-  !-> obs_nc2pdaf(local_dis(1)+1) = 2
+  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
+  !-> obs_nc2pdaf(local_disp_obs(1)+1) = 2
   !-> obs_nc2pdaf(1) = 2
 
   IF (ALLOCATED(obs)) DEALLOCATE(obs)
@@ -672,7 +672,7 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
                   idx_obs_nc_p(count)=idx_obs_nc(i)
                   !Allocate(sc_p(count)%scol_obs_in(nz_glob))       
               endif
-              obs_nc2pdaf(local_dis(mype_filter+1)+count) = i
+              obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
               count = count + 1
            end if
         end do
@@ -864,7 +864,7 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
                  !write(*,*) 'obs_index_p(',count,') is',obs_index_p(count)
                  obs_p(count) = clm_obs(i)
                  if(multierr.eq.1) clm_obserr_p(count) = clm_obserr(i)
-                 obs_nc2pdaf(local_dis(mype_filter+1)+count) = i
+                 obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
                  count = count + 1
                end if
 
@@ -957,7 +957,7 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
 
   !  clean up the temp data from nc file
   ! ------------------------------------
-  deallocate(local_dis)
+  deallocate(local_disp_obs)
   call clean_obs_nc()
 
 END SUBROUTINE init_dim_obs_pdaf

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -512,6 +512,17 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
     call abort_parallel()
   end if
 
+  !  Gather local dim obs in array
+  ! ------------------------------
+
+  ! allocate array of local observation dimensions with total PEs
+  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
+  ALLOCATE(local_dims_obs(npes_filter))
+
+  ! Gather array of local observation dimensions
+  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
+       comm_filter, ierror)
+
   allocate(local_dis(npes_filter))
   allocate(local_dim(npes_filter))
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dim, 1, MPI_INTEGER, comm_filter, ierror)
@@ -524,17 +535,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis
   end if
-
-  !  Gather local dim obs in array
-  ! ------------------------------
-
-  ! allocate array of local observation dimensions with total PEs
-  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
-  ALLOCATE(local_dims_obs(npes_filter))
-
-  ! Gather array of local observation dimensions
-  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
-       comm_filter, ierror)
 
   ! Write process-local observation arrays
   ! --------------------------------------

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -151,7 +151,7 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   INTEGER :: idx         ! Computed Index
   logical :: is_multi_observation_files
   character (len = 110) :: current_observation_filename
-  integer,allocatable :: local_dis(:),local_dim(:)
+  integer,allocatable :: local_dis(:)
   integer :: k_count !,nsc !hcp
   real    :: sum_interp_weights
 
@@ -523,14 +523,13 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
        comm_filter, ierror)
 
+  ! Set array local_dis (number of observations before process) from
+  ! local observation dimensions
   allocate(local_dis(npes_filter))
-  allocate(local_dim(npes_filter))
-  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dim, 1, MPI_INTEGER, comm_filter, ierror)
   local_dis(1) = 0
   do i = 2, npes_filter
-     local_dis(i) = local_dis(i-1) + local_dim(i-1)
+     local_dis(i) = local_dis(i-1) + local_dims_obs(i-1)
   end do
-  deallocate(local_dim)
 
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -531,6 +531,17 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_dis=", local_dis
   end if
 
+  !  Gather local dim obs in array
+  ! ------------------------------
+
+  ! allocate array of local observation dimensions with total PEs
+  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
+  ALLOCATE(local_dims_obs(npes_filter))
+
+  ! Gather array of local observation dimensions
+  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
+       comm_filter, ierror)
+
   ! Write process-local observation arrays
   ! --------------------------------------
   ! allocate index for mapping between observations in nc input and
@@ -949,14 +960,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_nc2pdaf=", obs_nc2pdaf
   end if
-
-  ! allocate array of local observation dimensions with total PEs
-  IF (ALLOCATED(local_dims_obs)) DEALLOCATE(local_dims_obs)
-  ALLOCATE(local_dims_obs(npes_filter))
-
-  ! Gather array of local observation dimensions 
-  call mpi_allgather(dim_obs_p, 1, MPI_INTEGER, local_dims_obs, 1, MPI_INTEGER, &
-       comm_filter, ierror)
 
 #ifndef CLMSA
 #ifndef OBS_ONLY_CLM

--- a/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
@@ -70,6 +70,7 @@ MODULE mod_assimilation
   INTEGER, ALLOCATABLE :: obs_interp_indices_p(:,:)  ! Vector holding state-vector indices of grid cells surrounding interpolation for PE-local domain
   INTEGER, ALLOCATABLE :: obs_interp_weights_p(:,:)  ! Vector holding weights of grid cells surrounding observation for PE-local domain
   INTEGER, ALLOCATABLE :: local_dims_obs(:) ! Array for process-local observation dimensions
+  INTEGER, ALLOCATABLE :: local_disp_obs(:) ! Observation displacement array for gathering. Displacement: #obs before current PE
   INTEGER, ALLOCATABLE :: obs_nc2pdaf(:)  ! mapping ordering of obs between netcdf input and internal ordering in pdaf
   REAL, ALLOCATABLE :: pressure_obserr_p(:) ! Vector holding observation errors for paraflow run at each PE-local domain 
   !hcp

--- a/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
@@ -84,7 +84,7 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   INTEGER :: ierror, max_var_id
   INTEGER :: i                         ! Counter
   REAL, ALLOCATABLE :: m_state_tmp(:)  ! Temporary process-local state vector
-  INTEGER, ALLOCATABLE :: local_dis(:) ! Displacement array for gathering
+  INTEGER, ALLOCATABLE :: local_disp_obs(:) ! Displacement array for gathering
   INTEGER, ALLOCATABLE :: m_id_p_tmp(:)
   INTEGER, ALLOCATABLE :: m_id_f_tmp(:)
 
@@ -108,24 +108,24 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   END DO
   
   ! Gather full observed state
-  ALLOCATE(local_dis(npes_filter))
+  ALLOCATE(local_disp_obs(npes_filter))
 
   !print *,'local_dims_obs(mype_filter+1) ', local_dims_obs(mype_filter+1)
   !print *,'dim_obs_p ', dim_obs_p
 
-  local_dis(1) = 0
+  local_disp_obs(1) = 0
   DO i = 2, npes_filter
-     local_dis(i) = local_dis(i-1) + local_dims_obs(i-1)
+     local_disp_obs(i) = local_disp_obs(i-1) + local_dims_obs(i-1)
   END DO
 
   ! gather local observed states of different sizes in a vector 
   CALL mpi_allgatherv(m_state_tmp, local_dims_obs(mype_filter+1), &
-       MPI_DOUBLE_PRECISION, m_state_f, local_dims_obs, local_dis, &  
+       MPI_DOUBLE_PRECISION, m_state_f, local_dims_obs, local_disp_obs, &  
        MPI_DOUBLE_PRECISION, comm_filter, ierror)
 
   ! gather m_id_p 
   CALL mpi_allgatherv(m_id_p_tmp, local_dims_obs(mype_filter+1), &
-       MPI_INT, m_id_f, local_dims_obs, local_dis, &  
+       MPI_INT, m_id_f, local_dims_obs, local_disp_obs, &  
        MPI_INT, comm_filter, ierror)
 
   ! resort m_id_p
@@ -138,6 +138,6 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   enddo
 
   ! Clean up
-  DEALLOCATE(m_state_tmp, local_dis,m_id_p_tmp,m_id_f_tmp)
+  DEALLOCATE(m_state_tmp, local_disp_obs,m_id_p_tmp,m_id_f_tmp)
 
 END SUBROUTINE obs_op_f_pdaf


### PR DESCRIPTION
### move setting of `local_dims_obs` to dimension-setting-code

`local_dims_obs` was before set at the end of the global observation
initalization routines. However, it is more fitting to set it in the
code-part, where the observation dimensions are set, not after the
code part, where observation arrays are filled.

### deallocate `local_dims_obs` at the very end of code

Before `local_dims_obs` was only deallocated directly before
allocation.

### move allocation and gather of `local_dims_obs` again

### removed unnecessary local array `local_dim`

`local_dim` is local clone of `local_dims_obs`. Therefore, `local_dim`
is removed and its role in setting the array `local_dis` is now filled
by `local_dims_obs`.

### rename `local_dis` to `local_disp_obs` and add to `mod_assimilation`

- clearer name `local_disp_obs`
- preventing code duplicity of setting `local_dis`
- simplified usage in observation operator routine

Disadvantage:
No immediate deallocation in local routine, should be ok as
`local_disp_obs` islength of number of PEs.

### simplify `obs_op_f_pdaf`

- use `dim_obs_p` where possible
- check that `dim_obs_p` is `local_dims_obs(mype_filter+1)`