### PR TITLE
TSMP-PDAF: Refactor setting and usage of `obs nc2pdaf`

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
@@ -52,6 +52,9 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
        ONLY: rms_obs, obs_nc2pdaf
 
   USE mod_read_obs, ONLY: multierr,clm_obserr, pressure_obserr
+  USE mod_parallel_pdaf, ONLY: mype_world
+  USE mod_parallel_pdaf, ONLY: abort_parallel
+  USE mod_tsmp, ONLY: point_obs
 
   IMPLICIT NONE
 
@@ -94,6 +97,13 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
 
  
   if(multierr.eq.1) then
+
+    ! Check that point observations are used
+    if (.not. point_obs .eq. 1) then
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(3) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      call abort_parallel()
+    end if
+
     do i=1,dim_obs_p
 #if defined CLMSA
       C_p(i,i) = C_p(i,i) + clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -63,7 +63,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
        ONLY: obs_p, obs_index_p, dim_obs, obs_filename, &
        obs, &
        pressure_obserr_p, clm_obserr_p, &
-       obs_nc2pdaf, &
        local_dims_obs, &
        local_disp_obs, &
        dim_obs_p, &
@@ -425,80 +424,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: local_disp_obs=", local_disp_obs
   end if
 
-  ! Write index mapping array NetCDF->PDAF
-  ! --------------------------------------
-  ! allocate index for mapping between observations in nc input and
-  ! sorted by pdaf: obs_nc2pdaf
-
-  ! Non-trivial example: The second observation in the NetCDF file
-  ! (`i=2`) is the only observation in the subgrid (`count = 1`) of
-  ! the first PE (`mype_filter = 0`):
-  !
-  ! i = 2
-  ! count = 1
-  ! mype_filter = 0
-  ! 
-  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
-  !-> obs_nc2pdaf(local_disp_obs(1)+1) = 2
-  !-> obs_nc2pdaf(1) = 2
-
-  if (allocated(obs_nc2pdaf)) deallocate(obs_nc2pdaf)
-  allocate(obs_nc2pdaf(dim_obs))
-  obs_nc2pdaf = 0
-
-#ifndef CLMSA
-#ifndef OBS_ONLY_CLM
-  if (model .eq. tag_model_parflow) then
-  if (point_obs.eq.1) then
-
-    cnt = 1
-    do i = 1, dim_obs
-      do j = 1, enkf_subvecsize
-        if (idx_obs_nc(i) .eq. idx_map_subvec2state_fortran(j)) then
-          obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
-          cnt = cnt + 1
-        end if
-      end do
-    end do
-
-  end if
-  end if
-#endif
-#endif
-
-#ifndef PARFLOW_STAND_ALONE
-#ifndef OBS_ONLY_PARFLOW
-  if(model .eq. tag_model_clm) then
-  if(point_obs.eq.1) then
-
-    cnt = 1
-     do i = 1, dim_obs
-        k = 1
-       do j = begg,endg
-            if(is_use_dr) then
-                deltax = abs(lon(j)-clmobs_lon(i))
-                deltay = abs(lat(j)-clmobs_lat(i))
-            end if
-            if(((is_use_dr).and.(deltax.le.clmobs_dr(1)).and.(deltay.le.clmobs_dr(2))).or.((.not. is_use_dr).and.(longxy_obs(i) == longxy(k)) .and. (latixy_obs(i) == latixy(k)))) then
-              obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
-              cnt = cnt + 1
-           end if
-           k = k + 1
-        end do
-     end do
-
-  end if
-  end if
-#endif
-#endif
-
-  ! collect values from all PEs, by adding all PE-local arrays (works
-  ! since only the subsection belonging to a specific PE is non-zero)
-  call mpi_allreduce(MPI_IN_PLACE,obs_nc2pdaf,dim_obs,MPI_INTEGER,MPI_SUM,comm_filter,ierror)
-
-  if (mype_filter==0 .and. screen > 2) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_nc2pdaf=", obs_nc2pdaf
-  end if
 
   ! Write process-local observation arrays
   ! --------------------------------------

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -427,18 +427,29 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
   ! Write index mapping array NetCDF->PDAF
   ! --------------------------------------
-  ! allocate index for mapping between observations in nc input and
-  ! sorted by pdaf: obs_nc2pdaf
+  ! Set index mapping `obs_nc2pdaf` between observation order in
+  ! NetCDF input and observation order in pdaf as determined by domain
+  ! decomposition.
 
-  ! Non-trivial example: The second observation in the NetCDF file
-  ! (`i=2`) is the only observation in the subgrid (`count = 1`) of
-  ! the first PE (`mype_filter = 0`):
+  ! Use-case: Correct index order in loops over NetCDF-observation
+  ! file input arrays.
+
+  ! Trivial example: The order in the NetCDF file corresponds exactly
+  ! to the order in the domain decomposition in PDAF, e.g. for a
+  ! single PE per component model run.
+
+  ! Non-trivial example: The first observation in the NetCDF file is
+  ! not located in the domain/subgrid of the first PE. Rather, the
+  ! second observation in the NetCDF file (`i=2`) is the only
+  ! observation (`cnt = 1`) in the subgrid of the first PE
+  ! (`mype_filter = 0`). This leads to a non-trivial index mapping,
+  ! e.g. `obs_nc2pdaf(1)==2`:
   !
   ! i = 2
-  ! count = 1
+  ! cnt = 1
   ! mype_filter = 0
   ! 
-  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
+  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
   !-> obs_nc2pdaf(local_disp_obs(1)+1) = 2
   !-> obs_nc2pdaf(1) = 2
 
@@ -499,6 +510,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_nc2pdaf=", obs_nc2pdaf
   end if
+
 
   ! Write process-local observation arrays
   ! --------------------------------------

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -627,6 +627,8 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
 #endif
 #endif
 
+  ! collect values from all PEs, by adding all PE-local arrays (works
+  ! since only the subsection belonging to a specific PE is non-zero)
   call mpi_allreduce(MPI_IN_PLACE,obs_nc2pdaf,dim_obs,MPI_INTEGER,MPI_SUM,comm_filter,ierror)
 
   if (mype_filter==0 .and. screen > 2) then

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_pdaf.F90
@@ -540,18 +540,29 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
 
   ! Write index mapping array NetCDF->PDAF
   ! --------------------------------------
-  ! allocate index for mapping between observations in nc input and
-  ! sorted by pdaf: obs_nc2pdaf
+  ! Set index mapping `obs_nc2pdaf` between observation order in
+  ! NetCDF input and observation order in pdaf as determined by domain
+  ! decomposition.
 
-  ! Non-trivial example: The second observation in the NetCDF file
-  ! (`i=2`) is the only observation in the subgrid (`count = 1`) of
-  ! the first PE (`mype_filter = 0`):
+  ! Use-case: Correct index order in loops over NetCDF-observation
+  ! file input arrays.
+
+  ! Trivial example: The order in the NetCDF file corresponds exactly
+  ! to the order in the domain decomposition in PDAF, e.g. for a
+  ! single PE per component model run.
+
+  ! Non-trivial example: The first observation in the NetCDF file is
+  ! not located in the domain/subgrid of the first PE. Rather, the
+  ! second observation in the NetCDF file (`i=2`) is the only
+  ! observation (`cnt = 1`) in the subgrid of the first PE
+  ! (`mype_filter = 0`). This leads to a non-trivial index mapping,
+  ! e.g. `obs_nc2pdaf(1)==2`:
   !
   ! i = 2
-  ! count = 1
+  ! cnt = 1
   ! mype_filter = 0
   ! 
-  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+count) = i
+  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
   !-> obs_nc2pdaf(local_disp_obs(1)+1) = 2
   !-> obs_nc2pdaf(1) = 2
 

--- a/bldsva/intf_DA/pdaf/framework/init_obscovar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_obscovar_pdaf.F90
@@ -49,7 +49,10 @@ SUBROUTINE init_obscovar_pdaf(step, dim_obs, dim_obs_p, covar, m_state_p, &
     ! !USES:
     USE mod_assimilation, &
         ONLY: rms_obs, obs_nc2pdaf
+    USE mod_parallel_pdaf, ONLY: mype_world
+    USE mod_parallel_pdaf, ONLY: abort_parallel
     use mod_read_obs, only: multierr,clm_obserr, pressure_obserr
+    USE mod_tsmp, ONLY: point_obs
     use netcdf
 
     IMPLICIT NONE
@@ -113,6 +116,13 @@ SUBROUTINE init_obscovar_pdaf(step, dim_obs, dim_obs_p, covar, m_state_p, &
 
  
   if(multierr.eq.1) then
+
+    ! Check that point observations are used
+    if (.not. point_obs .eq. 1) then
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(1) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      call abort_parallel()
+    end if
+
     do i=1,dim_obs
 #if defined CLMSA
       covar(i,i) = clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))

--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -38,6 +38,8 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
    USE enkf_clm_mod, ONLY: init_clm_l_size, clmupdate_T
    USE mod_parallel_pdaf, ONLY: filterpe
 #endif
+   USE mod_parallel_pdaf, ONLY: mype_world
+   USE mod_parallel_pdaf, ONLY: abort_parallel
 !fin hcp
 
   USE mod_tsmp,&
@@ -52,6 +54,7 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
           xcoord_fortran, ycoord_fortran, zcoord_fortran, &
           model
 #endif
+  USE mod_tsmp, ONLY: point_obs
 
   USE, INTRINSIC :: iso_c_binding, ONLY: C_F_POINTER
 
@@ -119,6 +122,12 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
     call C_F_POINTER(xcoord,xcoord_fortran,[enkf_subvecsize])
     call C_F_POINTER(ycoord,ycoord_fortran,[enkf_subvecsize])
     call C_F_POINTER(zcoord,zcoord_fortran,[enkf_subvecsize])
+
+    ! Check that point observations are used
+    if (.not. point_obs .eq. 1) then
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(2) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      call abort_parallel()
+    end if
 
     ! localize HP
     DO j = 1, dim_obs

--- a/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
@@ -71,7 +71,7 @@ MODULE mod_assimilation
   INTEGER, ALLOCATABLE :: obs_interp_weights_p(:,:)  ! Vector holding weights of grid cells surrounding observation for PE-local domain
   INTEGER, ALLOCATABLE :: local_dims_obs(:) ! Array for process-local observation dimensions
   INTEGER, ALLOCATABLE :: local_disp_obs(:) ! Observation displacement array for gathering. Displacement: #obs before current PE
-  INTEGER, ALLOCATABLE :: obs_nc2pdaf(:)  ! mapping ordering of obs between netcdf input and internal ordering in pdaf
+  INTEGER, ALLOCATABLE :: obs_nc2pdaf(:)  ! index mapping of obs-order in netcdf input and obs-order in pdaf determined by domain-decomposition
   REAL, ALLOCATABLE :: pressure_obserr_p(:) ! Vector holding observation errors for paraflow run at each PE-local domain 
   !hcp
   !type :: scoltype


### PR DESCRIPTION
### move setting of `obs_nc2pdaf` out of observation setting loop

slightly longer compute time, but much clearer code

### add error checks for point observation usage

If no point observations are used, the usage of `obs_nc2pdaf` is
spurious.

### better doc for `obs_nc2pdaf`