### PR TITLE
PDAF: change `dim_obs_p` to `dim_obs` in `add_obs_error_pdaf` (LEnKF)

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
@@ -29,7 +29,7 @@
 ! !ROUTINE: add_obs_error_pdaf --- Add observation error covariance matrix
 !
 ! !INTERFACE:
-SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
+SUBROUTINE add_obs_error_pdaf(step, dim_obs, C_p)
 
 ! !DESCRIPTION:
 ! User-supplied routine for PDAF.
@@ -60,8 +60,8 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
 
 ! !ARGUMENTS:
   INTEGER, INTENT(in) :: step       ! Current time step
-  INTEGER, INTENT(in) :: dim_obs_p  ! Dimension of observation vector
-  REAL, INTENT(inout) :: C_p(dim_obs_p,dim_obs_p) ! Matrix to that
+  INTEGER, INTENT(in) :: dim_obs    ! Dimension of observation vector
+  REAL, INTENT(inout) :: C_p(dim_obs,dim_obs) ! Matrix to that
                                     ! observation covariance R is added
 
 ! !CALLING SEQUENCE:
@@ -90,7 +90,7 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
 ! *************************************
 
   if(multierr.ne.1) then
-    DO i = 1, dim_obs_p
+    DO i = 1, dim_obs
        C_p(i, i) = C_p(i, i) + variance_obs
     ENDDO
   endif
@@ -104,7 +104,7 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
       call abort_parallel()
     end if
 
-    do i=1,dim_obs_p
+    do i=1,dim_obs
 #if defined CLMSA
       C_p(i,i) = C_p(i,i) + clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))
 #else

--- a/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
@@ -48,11 +48,13 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
 ! Later revisions - see svn log
 !
 ! !USES:
-  USE mod_assimilation, ONLY: rms_obs
+  USE mod_assimilation, &
+       ONLY: rms_obs, obs_nc2pdaf
 
-  USE mod_read_obs, ONLY: multierr
-  USE mod_read_obs, ONLY: clm_obserr_p
-  USE mod_read_obs, ONLY: pressure_obserr_p
+  USE mod_read_obs, ONLY: multierr,clm_obserr, pressure_obserr
+  USE mod_parallel_pdaf, ONLY: mype_world
+  USE mod_parallel_pdaf, ONLY: abort_parallel
+  USE mod_tsmp, ONLY: point_obs
 
   IMPLICIT NONE
 
@@ -96,11 +98,17 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
  
   if(multierr.eq.1) then
 
+    ! Check that point observations are used
+    if (.not. point_obs .eq. 1) then
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(3) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      call abort_parallel()
+    end if
+
     do i=1,dim_obs_p
 #if defined CLMSA
-      C_p(i,i) = C_p(i,i) + clm_obserr_p(i)*clm_obserr_p(i)
+      C_p(i,i) = C_p(i,i) + clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))
 #else
-      C_p(i,i) = C_p(i,i) + pressure_obserr_p(i)*pressure_obserr_p(i)
+      C_p(i,i) = C_p(i,i) + pressure_obserr(obs_nc2pdaf(i))*pressure_obserr(obs_nc2pdaf(i))
 #endif
     enddo
   endif

--- a/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
@@ -48,13 +48,11 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
 ! Later revisions - see svn log
 !
 ! !USES:
-  USE mod_assimilation, &
-       ONLY: rms_obs, obs_nc2pdaf
+  USE mod_assimilation, ONLY: rms_obs
 
-  USE mod_read_obs, ONLY: multierr,clm_obserr, pressure_obserr
-  USE mod_parallel_pdaf, ONLY: mype_world
-  USE mod_parallel_pdaf, ONLY: abort_parallel
-  USE mod_tsmp, ONLY: point_obs
+  USE mod_read_obs, ONLY: multierr
+  USE mod_read_obs, ONLY: clm_obserr_p
+  USE mod_read_obs, ONLY: pressure_obserr_p
 
   IMPLICIT NONE
 
@@ -98,17 +96,11 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs_p, C_p)
  
   if(multierr.eq.1) then
 
-    ! Check that point observations are used
-    if (.not. point_obs .eq. 1) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(3) `point_obs.eq.1` needed for using obs_nc2pdaf."
-      call abort_parallel()
-    end if
-
     do i=1,dim_obs_p
 #if defined CLMSA
-      C_p(i,i) = C_p(i,i) + clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))
+      C_p(i,i) = C_p(i,i) + clm_obserr_p(i)*clm_obserr_p(i)
 #else
-      C_p(i,i) = C_p(i,i) + pressure_obserr(obs_nc2pdaf(i))*pressure_obserr(obs_nc2pdaf(i))
+      C_p(i,i) = C_p(i,i) + pressure_obserr_p(i)*pressure_obserr_p(i)
 #endif
     enddo
   endif


### PR DESCRIPTION
Former `dim_obs_p` in `add_obs_error_pdaf` was actually the size of the full observation vector and is therefore better called `dim_obs`.

The suffix `_p` is used in TSMP-PDAF for PE-local variables.