### PR TITLE
PDAF: Rename `dim_state` to `dim_p` in `localize_covar_pdaf`

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -4,7 +4,7 @@
 ! !ROUTINE: localize_covar_pdaf --- apply localization matrix in LEnKF
 !
 ! !INTERFACE:
-SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
+SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
 
 ! !DESCRIPTION:
 ! User-supplied routine for PDAF (local EnKF)
@@ -61,9 +61,9 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
   IMPLICIT NONE
 
 ! !ARGUMENTS:
-  INTEGER, INTENT(in) :: dim_state              ! State dimension
+  INTEGER, INTENT(in) :: dim_p                  ! PE-local state dimension
   INTEGER, INTENT(in) :: dim_obs                ! number of observations
-  REAL, INTENT(inout) :: HP(dim_obs, dim_state) ! Matrix HP
+  REAL, INTENT(inout) :: HP(dim_obs, dim_p)     ! Matrix HP
   REAL, INTENT(inout) :: HPH(dim_obs, dim_obs)  ! Matrix HPH
 
 ! *** local variables ***
@@ -131,7 +131,7 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
 
     ! localize HP
     DO j = 1, dim_obs
-       DO i = 1, dim_state
+       DO i = 1, dim_p
 
          ! Index in coordinate array only spans `enkf_subvecsize`.
          !
@@ -184,12 +184,12 @@ SUBROUTINE localize_covar_pdaf(dim_state, dim_obs, HP, HPH)
    IF(model==tag_model_clm)THEN
 
     ! localize HP
-    ! ncellxy=dim_state/dim_l
+    ! ncellxy=dim_p/dim_l
     if (.not. clmupdate_T.EQ.0) then
         dim_l = 2
     end if
 
-    ncellxy=dim_state/dim_l
+    ncellxy=dim_p/dim_l
     DO j = 1, dim_obs
       DO k=1,dim_l
         DO i = 1, ncellxy


### PR DESCRIPTION
This input variable to `localize_covar_pdaf` is the PE-local state dimension.

However, `dim_state` is a double-name with the global state dimension from module `mod_assimilation`.