### PR TITLE
PDAF: rename `obs_nc2pdaf` to `obs_pdaf2nc`

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/add_obs_error_pdaf.F90
@@ -49,7 +49,7 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs, C_p)
 !
 ! !USES:
   USE mod_assimilation, &
-       ONLY: rms_obs, obs_nc2pdaf
+       ONLY: rms_obs, obs_pdaf2nc
 
   USE mod_read_obs, ONLY: multierr,clm_obserr, pressure_obserr
   USE mod_parallel_pdaf, ONLY: mype_world
@@ -100,15 +100,15 @@ SUBROUTINE add_obs_error_pdaf(step, dim_obs, C_p)
 
     ! Check that point observations are used
     if (.not. point_obs .eq. 1) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(3) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(3) `point_obs.eq.1` needed for using obs_pdaf2nc."
       call abort_parallel()
     end if
 
     do i=1,dim_obs
 #if defined CLMSA
-      C_p(i,i) = C_p(i,i) + clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))
+      C_p(i,i) = C_p(i,i) + clm_obserr(obs_pdaf2nc(i))*clm_obserr(obs_pdaf2nc(i))
 #else
-      C_p(i,i) = C_p(i,i) + pressure_obserr(obs_nc2pdaf(i))*pressure_obserr(obs_nc2pdaf(i))
+      C_p(i,i) = C_p(i,i) + pressure_obserr(obs_pdaf2nc(i))*pressure_obserr(obs_pdaf2nc(i))
 #endif
     enddo
   endif

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -65,7 +65,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
        obs_interp_indices_p, &
        obs_interp_weights_p, &
        pressure_obserr_p, clm_obserr_p, &
-       obs_nc2pdaf, &
+       obs_pdaf2nc, &
        local_dims_obs, &
        local_disp_obs, &
        dim_obs_p, &
@@ -556,7 +556,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
   ! Write index mapping array NetCDF->PDAF
   ! --------------------------------------
-  ! Set index mapping `obs_nc2pdaf` between observation order in
+  ! Set index mapping `obs_pdaf2nc` between observation order in
   ! NetCDF input and observation order in pdaf as determined by domain
   ! decomposition.
 
@@ -572,19 +572,19 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   ! second observation in the NetCDF file (`i=2`) is the only
   ! observation (`cnt = 1`) in the subgrid of the first PE
   ! (`mype_filter = 0`). This leads to a non-trivial index mapping,
-  ! e.g. `obs_nc2pdaf(1)==2`:
+  ! e.g. `obs_pdaf2nc(1)==2`:
   !
   ! i = 2
   ! cnt = 1
   ! mype_filter = 0
   ! 
-  ! obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
-  !-> obs_nc2pdaf(local_disp_obs(1)+1) = 2
-  !-> obs_nc2pdaf(1) = 2
+  ! obs_pdaf2nc(local_disp_obs(mype_filter+1)+cnt) = i
+  !-> obs_pdaf2nc(local_disp_obs(1)+1) = 2
+  !-> obs_pdaf2nc(1) = 2
 
-  if (allocated(obs_nc2pdaf)) deallocate(obs_nc2pdaf)
-  allocate(obs_nc2pdaf(dim_obs))
-  obs_nc2pdaf = 0
+  if (allocated(obs_pdaf2nc)) deallocate(obs_pdaf2nc)
+  allocate(obs_pdaf2nc(dim_obs))
+  obs_pdaf2nc = 0
 
 #ifndef CLMSA
 #ifndef OBS_ONLY_CLM
@@ -595,7 +595,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
     do i = 1, dim_obs
       do j = 1, enkf_subvecsize
         if (idx_obs_nc(i) .eq. idx_map_subvec2state_fortran(j)) then
-          obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
+          obs_pdaf2nc(local_disp_obs(mype_filter+1)+cnt) = i
           cnt = cnt + 1
         end if
       end do
@@ -626,7 +626,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
               end if
 
               if(((is_use_dr).and.(deltax.le.clmobs_dr(1)).and.(deltay.le.clmobs_dr(2))).or.((.not. is_use_dr).and.(longxy_obs(i) == longxy(g-begg+1)) .and. (latixy_obs(i) == latixy(g-begg+1)))) then
-                obs_nc2pdaf(local_disp_obs(mype_filter+1)+cnt) = i
+                obs_pdaf2nc(local_disp_obs(mype_filter+1)+cnt) = i
                 cnt = cnt + 1
               end if
 
@@ -645,10 +645,10 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
   ! collect values from all PEs, by adding all PE-local arrays (works
   ! since only the subsection belonging to a specific PE is non-zero)
-  call mpi_allreduce(MPI_IN_PLACE,obs_nc2pdaf,dim_obs,MPI_INTEGER,MPI_SUM,comm_filter,ierror)
+  call mpi_allreduce(MPI_IN_PLACE,obs_pdaf2nc,dim_obs,MPI_INTEGER,MPI_SUM,comm_filter,ierror)
 
   if (mype_filter==0 .and. screen > 2) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_nc2pdaf=", obs_nc2pdaf
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_pdaf2nc=", obs_pdaf2nc
   end if
 
 

--- a/bldsva/intf_DA/pdaf/framework/init_obscovar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_obscovar_pdaf.F90
@@ -48,7 +48,7 @@ SUBROUTINE init_obscovar_pdaf(step, dim_obs, dim_obs_p, covar, m_state_p, &
     !
     ! !USES:
     USE mod_assimilation, &
-        ONLY: rms_obs, obs_nc2pdaf
+        ONLY: rms_obs, obs_pdaf2nc
     USE mod_parallel_pdaf, ONLY: mype_world
     USE mod_parallel_pdaf, ONLY: abort_parallel
     use mod_read_obs, only: multierr,clm_obserr, pressure_obserr
@@ -119,15 +119,15 @@ SUBROUTINE init_obscovar_pdaf(step, dim_obs, dim_obs_p, covar, m_state_p, &
 
     ! Check that point observations are used
     if (.not. point_obs .eq. 1) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(1) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(1) `point_obs.eq.1` needed for using obs_pdaf2nc."
       call abort_parallel()
     end if
 
     do i=1,dim_obs
 #if defined CLMSA
-      covar(i,i) = clm_obserr(obs_nc2pdaf(i))*clm_obserr(obs_nc2pdaf(i))
+      covar(i,i) = clm_obserr(obs_pdaf2nc(i))*clm_obserr(obs_pdaf2nc(i))
 #else
-      covar(i,i) = pressure_obserr(obs_nc2pdaf(i))*pressure_obserr(obs_nc2pdaf(i))
+      covar(i,i) = pressure_obserr(obs_pdaf2nc(i))*pressure_obserr(obs_pdaf2nc(i))
 #endif
     enddo
   endif

--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -18,17 +18,17 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
 !
 ! !USES:
   USE mod_assimilation, &
-!    ONLY: cradius, sradius, locweight, obs_nc2pdaf
+!    ONLY: cradius, sradius, locweight, obs_pdaf2nc
 ! hcp
 ! we need to store the coordinates of the state vector 
 ! and obs array in longxy, latixy, and longxy_obs, latixy_obs
 ! respectively
 #if defined CLMSA
-    ONLY: cradius, sradius, locweight, obs_nc2pdaf, &
+    ONLY: cradius, sradius, locweight, obs_pdaf2nc, &
           longxy, latixy, longxy_obs, latixy_obs
 !hc  end
 #else
-    ONLY: cradius, sradius, locweight, obs_nc2pdaf
+    ONLY: cradius, sradius, locweight, obs_pdaf2nc
 #endif
 !fin hcp
 
@@ -125,7 +125,7 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
 
     ! Check that point observations are used
     if (.not. point_obs .eq. 1) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(2) `point_obs.eq.1` needed for using obs_nc2pdaf."
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR(2) `point_obs.eq.1` needed for using obs_pdaf2nc."
       call abort_parallel()
     end if
 
@@ -140,8 +140,8 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
          ! corresponds to a single coordinate array.
          icoord = modulo(i,enkf_subvecsize)
 
-         dx = abs(x_idx_obs_nc(obs_nc2pdaf(j)) - int(xcoord_fortran(icoord))-1)
-         dy = abs(y_idx_obs_nc(obs_nc2pdaf(j)) - int(ycoord_fortran(icoord))-1)
+         dx = abs(x_idx_obs_nc(obs_pdaf2nc(j)) - int(xcoord_fortran(icoord))-1)
+         dy = abs(y_idx_obs_nc(obs_pdaf2nc(j)) - int(ycoord_fortran(icoord))-1)
          distance = sqrt(real(dx)**2 + real(dy)**2)
     
          ! Compute weight
@@ -158,8 +158,8 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
        DO i = 1, dim_obs
     
          ! Compute distance
-         dx = abs(x_idx_obs_nc(obs_nc2pdaf(j)) - x_idx_obs_nc(obs_nc2pdaf(i)))
-         dy = abs(y_idx_obs_nc(obs_nc2pdaf(j)) - y_idx_obs_nc(obs_nc2pdaf(i)))
+         dx = abs(x_idx_obs_nc(obs_pdaf2nc(j)) - x_idx_obs_nc(obs_pdaf2nc(i)))
+         dy = abs(y_idx_obs_nc(obs_pdaf2nc(j)) - y_idx_obs_nc(obs_pdaf2nc(i)))
          distance = sqrt(real(dx)**2 + real(dy)**2)
     
          ! Compute weight
@@ -217,7 +217,7 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
          ! Compute distance: obs - obs
          dx = abs(longxy_obs(j) - longxy_obs(i))
          dy = abs(latixy_obs(j) - latixy_obs(i))
-!         dy = abs(y_idx_obs_nc(obs_nc2pdaf(j)) - y_idx_obs_nc(obs_nc2pdaf(i)))
+!         dy = abs(y_idx_obs_nc(obs_pdaf2nc(j)) - y_idx_obs_nc(obs_pdaf2nc(i)))
          distance = sqrt(real(dx)**2 + real(dy)**2)
     
          ! Compute weight

--- a/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
@@ -71,7 +71,9 @@ MODULE mod_assimilation
   INTEGER, ALLOCATABLE :: obs_interp_weights_p(:,:)  ! Vector holding weights of grid cells surrounding observation for PE-local domain
   INTEGER, ALLOCATABLE :: local_dims_obs(:) ! Array for process-local observation dimensions
   INTEGER, ALLOCATABLE :: local_disp_obs(:) ! Observation displacement array for gathering. Displacement: #obs before current PE
-  INTEGER, ALLOCATABLE :: obs_nc2pdaf(:)  ! index mapping of obs-order in netcdf input and obs-order in pdaf determined by domain-decomposition
+  ! pdaf-ordered index: determined by domain-decomposition
+  ! nc-ordered index:   pure ordering of observation in NetCDF observation file
+  INTEGER, ALLOCATABLE :: obs_pdaf2nc(:)  ! index mapping from a pdaf-ordered index to a nc-ordered index
   REAL, ALLOCATABLE :: pressure_obserr_p(:) ! Vector holding observation errors for paraflow run at each PE-local domain 
   !hcp
   !type :: scoltype


### PR DESCRIPTION
Reason: `obs_pdaf2nc` takes as input a pdaf-ordered index (subdivision according to PEs) and outputs the nc-ordered index (order from the NetCDF observation file)