### PR TITLE
PDAF: LEnKF for eCLM-PDAF

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -35,6 +35,7 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
   USE mod_read_obs,&
   ONLY: x_idx_obs_nc, y_idx_obs_nc, z_idx_obs_nc
 #if defined CLMSA
+   USE shr_kind_mod , only : r8 => shr_kind_r8
    USE mod_read_obs, ONLY: clmobs_lon
    USE mod_read_obs, ONLY: clmobs_lat
    USE enkf_clm_mod, ONLY: init_clm_l_size, clmupdate_T

--- a/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/localize_covar_pdaf.F90
@@ -96,6 +96,7 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
   ! INTEGER :: k
   real(r8), pointer :: lon(:)
   real(r8), pointer :: lat(:)
+  integer, pointer :: mycgridcell(:) !Pointer for CLM3.5/CLM5.0 col->gridcell index arrays
 #endif
   INTEGER :: icoord
 
@@ -224,8 +225,8 @@ SUBROUTINE localize_covar_pdaf(dim_p, dim_obs, HP, HPH)
          ! dy = abs(latixy_obs(j) - latixy(state_pdaf2clm_c_p(i)))
 
          ! Units: lat/lon
-         dx = abs(clmobs_lon(obs_pdaf2nc(j)) - lon(mygridcell(state_pdaf2clm_c_p(i))))
-         dy = abs(clmobs_lat(obs_pdaf2nc(j)) - lat(mygridcell(state_pdaf2clm_c_p(i))))
+         dx = abs(clmobs_lon(obs_pdaf2nc(j)) - lon(mycgridcell(state_pdaf2clm_c_p(i))))
+         dy = abs(clmobs_lat(obs_pdaf2nc(j)) - lat(mycgridcell(state_pdaf2clm_c_p(i))))
 
          distance = sqrt(real(dx)**2 + real(dy)**2)
     

--- a/bldsva/intf_DA/pdaf/model/clm5_0/enkf_clm_mod_5.F90
+++ b/bldsva/intf_DA/pdaf/model/clm5_0/enkf_clm_mod_5.F90
@@ -41,6 +41,8 @@ module enkf_clm_mod
   integer :: clm_begc,clm_endc
   integer :: clm_begp,clm_endp
   real(r8),allocatable :: clm_statevec(:)
+  integer,allocatable :: state_pdaf2clm_c_p(:)
+  integer,allocatable :: state_pdaf2clm_j_p(:)
   ! clm_paramarr: Contains LAI used in obs_op_pdaf for computing model
   ! LST in LST assimilation (clmupdate_T)
   real(r8),allocatable :: clm_paramarr(:)  !hcp CLM parameter vector (f.e. LAI)
@@ -208,6 +210,8 @@ module enkf_clm_mod
     if ((clmupdate_swc.ne.0) .or. (clmupdate_T.ne.0) .or. (clmupdate_texture.ne.0)) then
       !hcp added condition
       allocate(clm_statevec(clm_statevecsize))
+      allocate(state_pdaf2clm_c_p(clm_statevecsize))
+      allocate(state_pdaf2clm_j_p(clm_statevecsize))
     end if
 
     !write(*,*) 'clm_paramsize is ',clm_paramsize
@@ -268,10 +272,14 @@ module enkf_clm_mod
               if(clmstatevec_only_active.eq.1) then
                 if(i<=clmstatevec_max_layer .and. col%hydrologically_active(jj) .and. i<=col%nbedrock(jj) ) then
                   clm_statevec(cc+offset) = swc(jj,i)
+                  state_pdaf2clm_c_p(cc+offset) = jj
+                  state_pdaf2clm_j_p(cc+offset) = i
                   cc = cc + 1
                 end if
               else
                 clm_statevec(cc+offset) = swc(jj,i)
+                state_pdaf2clm_c_p(cc+offset) = jj
+                state_pdaf2clm_j_p(cc+offset) = i
                 cc = cc + 1
               end if
 
@@ -288,6 +296,8 @@ module enkf_clm_mod
                   if (newgridcell) then
                     newgridcell = .false.
                     clm_statevec(cc+offset) = swc(jj,i)
+                    state_pdaf2clm_c_p(cc+offset) = jj
+                    state_pdaf2clm_j_p(cc+offset) = i
                   endif
                 endif
               end do

--- a/bldsva/intf_DA/pdaf/model/eclm/enkf_clm_mod_5.F90
+++ b/bldsva/intf_DA/pdaf/model/eclm/enkf_clm_mod_5.F90
@@ -41,6 +41,8 @@ module enkf_clm_mod
   integer :: clm_begc,clm_endc
   integer :: clm_begp,clm_endp
   real(r8),allocatable :: clm_statevec(:)
+  integer,allocatable :: state_pdaf2clm_c_p(:)
+  integer,allocatable :: state_pdaf2clm_j_p(:)
   ! clm_paramarr: Contains LAI used in obs_op_pdaf for computing model
   ! LST in LST assimilation (clmupdate_T)
   real(r8),allocatable :: clm_paramarr(:)  !hcp CLM parameter vector (f.e. LAI)
@@ -208,6 +210,8 @@ module enkf_clm_mod
     if ((clmupdate_swc.ne.0) .or. (clmupdate_T.ne.0) .or. (clmupdate_texture.ne.0)) then
       !hcp added condition
       allocate(clm_statevec(clm_statevecsize))
+      allocate(state_pdaf2clm_c_p(clm_statevecsize))
+      allocate(state_pdaf2clm_j_p(clm_statevecsize))
     end if
 
     !write(*,*) 'clm_paramsize is ',clm_paramsize
@@ -268,10 +272,14 @@ module enkf_clm_mod
               if(clmstatevec_only_active.eq.1) then
                 if(i<=clmstatevec_max_layer .and. col%hydrologically_active(jj) .and. i<=col%nbedrock(jj) ) then
                   clm_statevec(cc+offset) = swc(jj,i)
+                  state_pdaf2clm_c_p(cc+offset) = jj
+                  state_pdaf2clm_j_p(cc+offset) = i
                   cc = cc + 1
                 end if
               else
                 clm_statevec(cc+offset) = swc(jj,i)
+                state_pdaf2clm_c_p(cc+offset) = jj
+                state_pdaf2clm_j_p(cc+offset) = i
                 cc = cc + 1
               end if
 
@@ -288,6 +296,8 @@ module enkf_clm_mod
                   if (newgridcell) then
                     newgridcell = .false.
                     clm_statevec(cc+offset) = swc(jj,i)
+                    state_pdaf2clm_c_p(cc+offset) = jj
+                    state_pdaf2clm_j_p(cc+offset) = i
                   endif
                 endif
               end do


### PR DESCRIPTION
- IMPORTANT: Changed from index-distance to lat/lon distance

- introduce PE-local index transformation arrays `state_pdaf2clm_c_p` (column) and `state_pdaf2clm_j_p` (layer)

- loop over global pdaf-ordered observations and PE-local pdaf-ordered state

- manage access to the arrays with index transformation arrays, e.g. `lon(mygridcell(state_pdaf2clm_c_p(i))))` transforms the PE-local pdaf-ordered state index `i`: (1) to the CLM column index, (2) to the CLM gridcell index and (3) to the gridcell's longitude.