### PR TITLE
PDAF: give character `outdir` length 100

### DIFF
--- a/bldsva/intf_DA/pdaf/model/clm3_5/enkf_clm_mod.F90
+++ b/bldsva/intf_DA/pdaf/model/clm3_5/enkf_clm_mod.F90
@@ -76,7 +76,7 @@ module enkf_clm_mod
   real(r8) :: dtime     ! time step increment (sec)
   integer  :: ier       ! error code
 
-  character(c_char),bind(C,name="outdir"),target :: outdir
+  character(kind=c_char,len=100),bind(C,name="outdir"),target :: outdir
 
   logical  :: log_print    ! true=> print diagnostics
   real(r8) :: eccf         ! earth orbit eccentricity factor

--- a/bldsva/intf_DA/pdaf/model/clm5_0/enkf_clm_mod_5.F90
+++ b/bldsva/intf_DA/pdaf/model/clm5_0/enkf_clm_mod_5.F90
@@ -63,7 +63,7 @@ module enkf_clm_mod
   real(r8) :: dtime     ! time step increment (sec)
   integer  :: ier       ! error code
 
-  character(c_char),bind(C,name="outdir"),target :: outdir
+  character(kind=c_char,len=100),bind(C,name="outdir"),target :: outdir
 
   logical  :: log_print    ! true=> print diagnostics
   real(r8) :: eccf         ! earth orbit eccentricity factor

--- a/bldsva/intf_DA/pdaf/model/eclm/enkf_clm_mod_5.F90
+++ b/bldsva/intf_DA/pdaf/model/eclm/enkf_clm_mod_5.F90
@@ -63,7 +63,7 @@ module enkf_clm_mod
   real(r8) :: dtime     ! time step increment (sec)
   integer  :: ier       ! error code
 
-  character(c_char),bind(C,name="outdir"),target :: outdir
+  character(kind=c_char,len=100),bind(C,name="outdir"),target :: outdir
 
   logical  :: log_print    ! true=> print diagnostics
   real(r8) :: eccf         ! earth orbit eccentricity factor


### PR DESCRIPTION
Goal: Eliminate the following warning that appears in `Stages/2024`:

ld: warning: size of symbol `outdir' changed

from 1 in
`${CMAKE_INSTALL_PREFIX}/lib/libmodel.a(enkf_clm_mod_5.o)`

to 100 in
`${CMAKE_INSTALL_PREFIX}/lib/libmodel.a(wrapper_tsmp.o)`