### PR TITLE
Update files TSMP1 for Jedi and Gnu (note: build for clm3 + parflow cpu)

### DIFF
--- a/bldsva/build_tsmp.ksh
+++ b/bldsva/build_tsmp.ksh
@@ -39,7 +39,7 @@ getDefaults(){
   def_optComp=""   # will be set to platform defaults if empty
 
   #compiler options, CPS remove hardwiring of compilers
-  def_compiler="Intel" # set Intel default if not explicitly set
+  def_compiler="Gnu" # set Intel default if not explicitly set
   def_processor="CPU"
   def_debugswitch=""  # debug compilation switch
 
@@ -67,7 +67,7 @@ getDefaults(){
 setDefaults(){
   #load the default values
   platform=$def_platform
-  if [[ $platform == "" ]] then ; platform="JUWELS" ; fi #We need a hard default here
+  if [[ $platform == "" ]] then ; platform="JEDI" ; fi #We need a hard default here
   version=$def_combination
   if [[ $version == "" ]] then ; version="" ; fi #We need a hard default here
   rootdir=$def_rootdir
@@ -260,6 +260,8 @@ setCombination(){
 compileClm(){
 route "${cyellow}> c_compileClm${cnormal}"
   comment "  source clm interface script"
+    export FCFLAGS="-w -fallow-argument-mismatch -O2"
+    export FFLAGS="-w -fallow-argument-mismatch -O2"
     comment "intf_oas3/${mList[1]}/arch/build_interface_${mList[1]}.ksh"
     . ${rootdir}/bldsva/intf_oas3/${mList[1]}/arch/build_interface_${mList[1]}.ksh >> $log_file 2>> $err_file
   check

--- a/bldsva/intf_oas3/cosmo5_1/arch/build_interface_cosmo5_1.ksh
+++ b/bldsva/intf_oas3/cosmo5_1/arch/build_interface_cosmo5_1.ksh
@@ -22,12 +22,12 @@ check
 comment "   sed ldflg to cos Makefile"
   sed -i "s@__ldflg__@@" $file >> $log_file 2>> $err_file
 check
-  if [[ $compiler == "Gnu" ]]; then
+  if  echo "$compiler" | grep -qE 'Gnu' ; then
      comment "   sed comF90 based on Gnu to cos Makefile"
           if [[ $profiling == "scalasca" ]]; then
-        sed -i "s@__comF90__@scorep-mpif90 -cpp -c -ffree-line-length-0 -fstack-protector-all -finit-real=nan -finit-integer=-2147483648 -finit-character=127 -ffpe-trap=invalid,zero,overflow@" $file >> $log_file 2>> $err_file
+        sed -i "s@__comF90__@scorep-mpif90 -cpp -c -fallow-argument-mismatch -ffree-line-length-0 -fstack-protector-all -finit-real=nan -finit-integer=-2147483648 -finit-character=127 -ffpe-trap=invalid,zero,overflow@" $file >> $log_file 2>> $err_file
      else
-        sed -i "s@__comF90__@$profComp $mpiPath/bin/mpif90 -cpp -c -ffree-line-length-0 -fstack-protector-all -finit-real=nan -finit-integer=-2147483648 -finit-character=127 -ffpe-trap=invalid,zero,overflow@" $file >> $log_file 2>> $err_file
+        sed -i "s@__comF90__@$profComp $mpiPath/bin/mpif90 -cpp -c -fallow-argument-mismatch -ffree-line-length-0 -fstack-protector-all -finit-real=nan -finit-integer=-2147483648 -finit-character=127 -ffpe-trap=invalid,zero,overflow@" $file >> $log_file 2>> $err_file
      fi
      check
      comment "   sed comflg to cos Makefile"

--- a/bldsva/intf_oas3/oasis3-mct/arch/build_interface_oasis3-mct.ksh
+++ b/bldsva/intf_oas3/oasis3-mct/arch/build_interface_oasis3-mct.ksh
@@ -101,7 +101,11 @@ route "${cyellow}>> configure_oas${cnormal}"
     sed -i 's@__inc__@-I$(LIBBUILD)/psmile.$(CHAN) -I$(LIBBUILD)/scrip  -I$(LIBBUILD)/mct'" -I$ncdfPath/include@" $file >> $log_file 2>> $err_file
   check
   comment "   sed ldflg to oas Makefile"
-    sed -i "s@__ldflg__@@" $file >> $log_file 2>> $err_file
+    if echo "$compiler" | grep -qE 'Gnu'; then
+      sed -i "s@__ldflg__@-w -fallow-argument-mismatch -O2@" $file >> $log_file 2>> $err_file
+    else
+      sed -i "s@__ldflg__@@" $file >> $log_file 2>> $err_file
+    fi
   check
   comment "   sed comF90 to oas Makefile"
     if [[ $profiling == "scalasca" ]]; then
@@ -130,8 +134,10 @@ route "${cyellow}>> configure_oas${cnormal}"
   comment "   sed precision to oas Makefile"
     if [[ $compiler == "Intel" ]]; then
       sed -i "s@__precision__@-i4 -r8@" $file >> $log_file 2>> $err_file
+      sed -i "s@__allow__@@" $file >> $log_file 2>> $err_file
     else
       sed -i "s@__precision__@@" $file >> $log_file 2>> $err_file
+      sed -i "s@__allow__@-w -fallow-argument-mismatch -O2@" $file >> $log_file 2>> $err_file
     fi
   check
 

--- a/bldsva/intf_oas3/oasis3-mct/arch/config/make.intel_oa3
+++ b/bldsva/intf_oas3/oasis3-mct/arch/config/make.intel_oa3
@@ -44,13 +44,14 @@ CPPDEF    =  -Duse_libMPI -Duse_netCDF -Duse_comm_$(CHAN) -DVERBOSE -DDEBUG -DTR
 # For compiling in double precision, put -r8
 # For compiling in single precision, remove -r8 and add -Duse_realtype_single
 # 
-F90FLAGS  = -C __precision__ $(PSMILE_INCDIR) $(CPPDEF)
+F90FLAGS  = -C __precision__ __allow__ $(PSMILE_INCDIR) $(CPPDEF)
 #
 f90FLAGS  = $(F90FLAGS)
 FFLAGS    = $(F90FLAGS)
 fFLAGS    = $(F90FLAGS)
 CCFLAGS   = $(PSMILE_INCDIR) $(CPPDEF)
 LDFLAGS   = __ldflg__
+FCFLAGS   = $(F90FLAGS)
 #
 # MPP_IOOPT needed for compiling mpp_io
 MPP_IOOPT = __precision__ 

--- a/bldsva/machines/config_JEDI.ksh
+++ b/bldsva/machines/config_JEDI.ksh
@@ -1,0 +1,355 @@
+#! /bin/ksh
+
+
+getMachineDefaults(){
+route "${cyellow}>> getMachineDefaults${cnormal}"
+  comment "   init lmod functionality"
+  . /p/software/jedi/lmod/lmod/init/ksh >> $log_file 2>> $err_file
+  check
+  comment "   source and load Modules on JEDI: loadenvs.$compiler"         
+  . $rootdir/bldsva/machines/loadenvs.$compiler >> $log_file 2>> $err_file
+  check
+
+  defaultMpiPath="$EBROOTOPENMPI"            # for OpenMPI
+  defaultMpiPath="$EBROOTPSMPI"              # for ParaStation
+  defaultNcdfPath="$EBROOTNETCDFMINFORTRAN"
+  
+  if [[ $compiler == "Gnu" ]] ; then
+    defaultGrib1Path="/p/project1/cslts/local/jureca/DWD-libgrib1_20110128_Gnu/lib/"
+  else
+    defaultGrib1Path="/p/project1/cslts/local/jureca/DWD-libgrib1_20110128_Gnu/lib/"
+  fi
+  
+  defaultGribPath="$EBROOTECCODES"
+  defaultGribapiPath="$EBROOTECCODES"
+  defaultJasperPath="$EBROOTJASPER"
+  defaultTclPath="$EBROOTTCL"
+  defaultHyprePath="$EBROOTHYPRE"
+  defaultSiloPath="$EBROOTSILO"                 # not on JEDI
+  
+  #defaultLapackPath="$EBROOTIMKL"              # This is for intel
+  defaultLapackPath="$EBROOTFLEXIBLAS"          # Alternative to Lapack on JEDI
+  
+  #defaultPncdfPath="$EBROOTPARALLELMINNETCDF"  # not on JEDI
+  defaultPncdfPath="$EBROOTPNETCDF"             # alternative for $EBROOTPARALLELMINNETCDF
+  
+  # Additional option for GPU compilation 
+  gpuMpiSettings="UCX-settings/RC-CUDA"
+  cuda_architectures="-DCMAKE_CUDA_ARCHITECTURES=80" 
+
+  # Default Compiler/Linker optimization
+  if [[ $compiler == "Gnu" ]] ; then
+      defaultOptC="-O2" # Gnu
+  else
+      defaultOptC="-O2" # Default
+  fi
+
+  profilingImpl=" no scalasca "  
+  if [[ $profiling == "scalasca" ]] ; then ; profComp="" ; profRun="scalasca -analyse" ; profVar=""  ;fi
+
+  # Default Processor settings
+  defaultwtime="01:00:00"
+  defaultQ="devel"
+
+route "${cyellow}<< getMachineDefaults${cnormal}"
+}
+
+finalizeMachine(){
+route "${cyellow}>> finalizeMachine${cnormal}"
+route "${cyellow}<< finalizeMachine${cnormal}"
+}
+
+# computes nodes based on number of processors and resources
+computeNodes(){
+processes=$1
+resources=$2
+echo $((processes%resources?processes/resources+1:processes/resources))
+}
+
+createRunscript(){
+route "${cyellow}>> createRunscript${cnormal}"
+comment "   copy JEDI module load script into rundirectory"
+  cp $rootdir/bldsva/machines/loadenvs.$compiler $rundir/loadenvs
+check
+
+mpitasks=$((numInst * ($nproc_icon + $nproc_cos + $nproc_clm + $nproc_pfl + $nproc_oas)))
+nnodes=`echo "scale = 2; $mpitasks / $nppn" | bc | perl -nl -MPOSIX -e 'print ceil($_);'`
+
+#DA
+if [[ $withPDAF == "true" ]] ; then
+  srun="srun -n $mpitasks ./tsmp-pdaf -n_modeltasks $(($numInst-$startInst)) -filtertype 2 -subtype 1 -delt_obs $delta_obs -rms_obs 0.03 -obs_filename swc_crp"
+else
+  srun="srun --multi-prog slm_multiprog_mapping.conf"
+fi
+if [[ $processor == "GPU" || $processor == "MSA" ]]; then
+nnode_cos=$((($nproc_cos)/$nppn)) 
+nnode_clm=$((($nproc_clm)/$nppn)) 
+nnode_pfl=$((($nproc_pfl)/$ngpn)) 
+
+nnode_cos=$(computeNodes $nproc_cos $nppn) 
+nnode_clm=$(computeNodes $nproc_clm $nppn) 
+nnode_pfl=$(computeNodes $nproc_pfl $ngpn)
+
+route "${cyellow}<< setting up heterogeneous/modular job${cnormal}"
+comment "  nppn=$nppn\t\t ngpn=$ngpn\n"
+comment "  Nproc: COSMO=$nproc_cos\tCLM=$nproc_clm\tPFL=$nproc_pfl\n"
+comment "  Nnode: COSMO=$nnode_cos\tCLM=$nnode_clm\tPFL=$nnode_pfl\n"
+ 
+if [[ $processor == "GPU" ]];then
+cat << EOF >> $rundir/tsmp_slm_run.bsh
+#!/bin/bash
+#SBATCH --account=slts
+#SBATCH --job-name="TSMP_Hetero"
+#SBATCH --output=hetro_job-out.%j
+#SBATCH --error=hetro_job-err.%j
+#SBATCH --time=$wtime
+#SBATCH -N $nnode_cos  --ntasks-per-node=$nppn -p batch
+#SBATCH hetjob
+#SBATCH -N $nnode_clm --ntasks-per-node=$nppn  -p batch
+#SBATCH hetjob
+#SBATCH -N $nnode_pfl --ntasks-per-node=$ngpn --gres=gpu:$ngpn -p gpus
+
+cd $rundir
+source $rundir/loadenvs
+export LD_LIBRARY_PATH="$rootdir/${mList[3]}_${platform}_${combination}/rmm/lib:\$LD_LIBRARY_PATH"
+date
+echo "started" > started.txt
+rm -rf YU*
+
+srun --het-group=0 ./lmparbin_pur :\\
+     --pack-group=1 ./clm :\\
+     --pack-group=2 ./parflow $pflrunname
+date
+echo "ready" > ready.txt
+exit 0
+
+EOF
+
+elif [[ $processor == "MSA" ]]; then
+cat << EOF >> $rundir/tsmp_slm_run.bsh
+#!/bin/bash
+#SBATCH --account=slts
+#SBATCH --job-name="TSMP_Hetero"
+#SBATCH --output=hetro_job-out.%j
+#SBATCH --error=hetro_job-err.%j
+#SBATCH --time=$wtime
+#SBATCH -N $nnode_cos  --ntasks-per-node=$nppn -p batch
+#SBATCH hetjob
+#SBATCH -N $nnode_clm --ntasks-per-node=$nppn -p batch
+#SBATCH hetjob
+#SBATCH -N $nnode_pfl --ntasks-per-node=$ngpn --gres=gpu:$ngpn -p booster
+
+cd $rundir
+source $rundir/loadenvs
+date
+echo "started" > started.txt
+rm -rf YU*
+
+srun --pack-group=0 xenv -P \\
+                         -U $OTHERSTAGES \\
+                         -L Stages/2022 \\
+                         -L Intel/2021.4.0 \\
+                         -L ParaStationMPI/5.5.0-1 \\
+                         -L netCDF/4.8.1 \\
+                         -L netCDF-Fortran/4.5.3 \\
+                         -L ecCodes/2.22.1 \\
+                         ./lmparbin_pur : \\
+     --pack-group=1 xenv -P \\
+                         -U $OTHERSTAGES \\
+                         -L Stages/2022 \\
+                         -L Intel/2021.4.0 \\
+                         -L ParaStationMPI/5.5.0-1 \\
+                         -L netCDF/4.8.1 \\
+                         -L netCDF-Fortran/4.5.3 \\
+                         ./clm : \\
+     --pack-group=2 xenv -P \\
+                         -U $OTHERSTAGES \\
+                         -L Stages/2022 \\
+                         -L Intel/2021.4.0 \\
+                         -L ParaStationMPI/5.5.0-1 \\
+                         -L netCDF/4.8.1 \\
+                         -L netCDF-Fortran/4.5.3 \\
+                         -L Silo/4.11 \\
+                         LD_LIBRARY_PATH+=$rootdir/${mList[3]}_${platform}_${combination}/rmm/lib \\
+                         ./parflow $pflrunname
+date
+echo "ready" > ready.txt
+exit 0
+EOF
+fi
+
+else
+
+cat << EOF >> $rundir/tsmp_slm_run.bsh
+#!/bin/bash
+
+#SBATCH --job-name="TSMP"
+#SBATCH --nodes=$nnodes
+#SBATCH --ntasks=$mpitasks
+#SBATCH --ntasks-per-node=$nppn
+#SBATCH --output=mpiMPMD-out.%j
+#SBATCH --error=mpiMPMD-err.%j
+#SBATCH --time=$wtime
+#SBATCH --partition=$queue
+#SBATCH --mail-type=NONE
+#SBATCH --account=slts 
+
+export PSP_RENDEZVOUS_OPENIB=-1
+
+cd $rundir
+source $rundir/loadenvs
+date
+echo "started" > started.txt
+rm -rf YU*
+export $profVar
+$srun
+date
+echo "ready" > ready.txt
+exit 0
+
+EOF
+
+fi
+
+
+
+
+counter=0
+#for mapfile
+start_oas=$counter
+end_oas=$(($start_oas+$nproc_oas-1))
+
+start_cos=$(($nproc_oas+$counter))
+end_cos=$(($start_cos+($numInst*$nproc_cos)-1))
+
+start_icon=$(($nproc_oas+$counter))
+end_icon=$(($start_icon+($numInst*$nproc_icon)-1))
+
+start_pfl=$(($numInst*($nproc_cos+$nproc_icon)+$nproc_oas+$counter))
+end_pfl=$(($start_pfl+($numInst*$nproc_pfl)-1))
+
+start_clm=$((($numInst*($nproc_cos+$nproc_icon))+$nproc_oas+($numInst*$nproc_pfl)+$counter))
+end_clm=$(($start_clm+($numInst*$nproc_clm)-1))
+
+if [[ $numInst > 1 &&  $withOASMCT == "true" ]] then
+ for instance in {$startInst..$(($startInst+$numInst-1))}
+ do
+  for iter in {1..$nproc_cos}
+  do
+    if [[ $withCOS == "true" ]] then ; echo $instance >>  $rundir/instanceMap.txt ;fi
+    if [[ $withICON == "true" ]] then ; echo $instance >>  $rundir/instanceMap.txt ;fi
+  done
+ done
+fi
+
+if [[ $numInst > 1 &&  $withOASMCT == "true" ]] then
+ for instance in {$startInst..$(($startInst+$numInst-1))}
+ do
+  for iter in {1..$nproc_icon}
+  do
+    if [[ $withICON == "true" ]] then ; echo $instance >>  $rundir/instanceMap.txt ;fi
+  done
+ done
+ for instance in {$startInst..$(($startInst+$numInst-1))}
+ do
+  for iter in {1..$nproc_pfl}
+  do
+    if [[ $withPFL == "true" ]] then ; echo $instance >>  $rundir/instanceMap.txt ;fi
+  done
+ done
+ for instance in {$startInst..$(($startInst+$numInst-1))}
+ do
+  for iter in {1..$nproc_clm}
+  do
+    if [[ $withCLM == "true" ]] then ; echo $instance >>  $rundir/instanceMap.txt ;fi
+  done
+ done
+fi
+
+
+if [[ $withCOS == "true" ]]; then
+cat << EOF >> $rundir/slm_multiprog_mapping.conf
+__oas__
+__cos__
+__pfl__
+__clm__
+
+EOF
+else
+cat << EOF >> $rundir/slm_multiprog_mapping.conf
+__oas__
+__icon__
+__pfl__
+__clm__
+
+EOF
+fi
+
+comment "   sed executables and processors into mapping file"
+	if [[ $withOAS == "false" ||  $withOASMCT == "true" ]] then ; sed "s/__oas__//" -i $rundir/slm_multiprog_mapping.conf  >> $log_file 2>> $err_file; check; fi
+	if [[ $withCOS == "false" ]] then ; sed "s/__cos__//" -i $rundir/slm_multiprog_mapping.conf  >> $log_file 2>> $err_file; check; fi
+	if [[ $withICON == "false" ]] then ; sed "s/__icon__//" -i $rundir/slm_multiprog_mapping.conf  >> $log_file 2>> $err_file; check; fi
+        if [[ $withPFL == "false" ]] then ; sed "s/__pfl__//" -i $rundir/slm_multiprog_mapping.conf  >> $log_file 2>> $err_file; check; fi
+        if [[ $withCLM == "false" ]] then ; sed "s/__clm__//" -i $rundir/slm_multiprog_mapping.conf  >> $log_file 2>> $err_file; check; fi
+
+
+sed "s/__oas__/$start_oas  $profRun \.\/oasis3.MPI1.x/" -i $rundir/slm_multiprog_mapping.conf >> $log_file 2>> $err_file
+check
+sed "s/__cos__/$start_cos-$end_cos  $profRun \.\/lmparbin_pur/" -i $rundir/slm_multiprog_mapping.conf >> $log_file 2>> $err_file
+check
+sed "s/__icon__/$start_icon-$end_icon  $profRun \.\/icon/" -i $rundir/slm_multiprog_mapping.conf >> $log_file 2>> $err_file
+check
+sed "s/__pfl__/$start_pfl-$end_pfl  $profRun \.\/parflow $pflrunname/" -i $rundir/slm_multiprog_mapping.conf >> $log_file 2>> $err_file
+check
+sed "s/__clm__/$start_clm-$end_clm  $profRun \.\/clm/" -i $rundir/slm_multiprog_mapping.conf >> $log_file 2>> $err_file
+check
+
+
+
+comment "   change permission of runscript and mapfile"
+chmod 755 $rundir/tsmp_slm_run.bsh >> $log_file 2>> $err_file
+check
+chmod 755 $rundir/slm_multiprog_mapping.conf >> $log_file 2>> $err_file
+check
+route "${cyellow}<< createRunscript${cnormal}"
+}
+
+Npp=48
+Ngp=4
+
+PFLProcXg=1
+PFLProcYg=4
+CLMProcXg=3
+CLMProcYg=8
+COSProcXg=12
+COSProcYg=16
+if [[ $refSetup == "cordex" ]] then
+	PFLProcX=9
+	PFLProcY=8
+	CLMProcX=3
+	CLMProcY=8
+	COSProcX=12
+	COSProcY=16
+	elif [[ $refSetup == "nrw" ]] then
+	PFLProcX=3
+	PFLProcY=4
+	CLMProcX=2
+	CLMProcY=2
+	COSProcX=4
+	COSProcY=8
+	elif [[ $refSetup == "idealRTD" ]] then
+	PFLProcX=2
+	PFLProcY=2
+	CLMProcX=2
+	CLMProcY=2
+	COSProcX=6
+	COSProcY=5
+	else 
+	PFLProcX=4
+	PFLProcY=4
+	CLMProcX=4
+	CLMProcY=2
+	COSProcX=8
+	COSProcY=8
+fi
+

--- a/bldsva/machines/loadenvs.Gnu
+++ b/bldsva/machines/loadenvs.Gnu
@@ -1,36 +1,35 @@
-#USAGE="source $0"
-#for bld and setup of TSMP 
-#for standard user
-#
+# Adapted to JEDI Stages/2024   AGN
 module --force purge
 module use $OTHERSTAGES
-module load Stages/2022
-module load GCC/11.2.0
-module load ParaStationMPI/5.5.0-1
+module load Stages/2024
+module load GCC/12.3.0
+module load ParaStationMPI/5.9.2-1    # needs EBROOTPSMPI in file config_JEDI
 #
-module load Hypre/2.23.0
-module load Silo/4.11
-module load Tcl/8.6.11 
+#module load OpenMPI/4.1.5            # needs EBROOTOPENMPI in file config_JEDI 
+#module load Hypre/2.31.0       
+
+#module load Silo/4.11                # not installed on JEDI
+module load Tcl/8.6.13 
 #
-module load ecCodes/2.22.1
-module load HDF5/1.12.1
-module load netCDF/4.8.1
-module load netCDF-Fortran/4.5.3
-module load PnetCDF/1.12.2
-module load cURL/7.78.0
-module load Szip/.2.1.1
-module load Python/3.9.6
-module load NCO/5.0.3
-module load CMake/3.21.1
-# module load CDO/2.0.2 
-# module load NCO/5.0.3 
+module load ecCodes/2.31.0 
+module load HDF5/1.14.2-serial 
+module load netCDF/4.9.2
+module load netCDF-Fortran/4.6.1
+module load PnetCDF/1.12.3
+module load cURL/8.0.1
+module load Szip/.2.1.1 
+module load Python/3.11.3
+module load CMake/3.26.3
+module load git/2.41.0-nodocs  
 
 # Modules for CLM5
-module load ESMF/8.2.0
-module load Perl/5.34.0
-module load imkl/2021.4.0
+#module load ESMF/8.2.0              # not installed on JEDI
+#module load imkl/2022.1.0           # not installed on JEDI
 # module load NVHPC/22.9
 # module load NCL/6.6.2
-module load netCDF-C++4/4.3.1
+#module load netCDF-C++4/4.3.1
+
+module load GCCcore/.12.3.0
+module load Perl/5.36.1
 
 module li

--- a/bldsva/machines/loadenvs.Gnu.2022
+++ b/bldsva/machines/loadenvs.Gnu.2022
@@ -1,0 +1,36 @@
+#USAGE="source $0"
+#for bld and setup of TSMP 
+#for standard user
+#
+module --force purge
+module use $OTHERSTAGES
+module load Stages/2022
+module load GCC/11.2.0
+module load ParaStationMPI/5.5.0-1
+#
+#module load Hypre/2.23.0
+module load Silo/4.11
+module load Tcl/8.6.11 
+#
+module load ecCodes/2.22.1
+module load HDF5/1.12.1
+module load netCDF/4.8.1
+module load netCDF-Fortran/4.5.3
+module load PnetCDF/1.12.2
+module load cURL/7.78.0
+module load Szip/.2.1.1
+module load Python/3.9.6
+module load NCO/5.0.3
+module load CMake/3.21.1
+# module load CDO/2.0.2 
+# module load NCO/5.0.3 
+
+# Modules for CLM5
+module load ESMF/8.2.0
+module load Perl/5.34.0
+module load imkl/2021.4.0
+# module load NVHPC/22.9
+# module load NCL/6.6.2
+module load netCDF-C++4/4.3.1
+
+module li

--- a/bldsva/machines/loadenvs.Gnu.2023
+++ b/bldsva/machines/loadenvs.Gnu.2023
@@ -1,0 +1,28 @@
+#USAGE="source $0"
+#for bld and setup of TSMP 
+#for standard user
+#
+module --force purge
+module use $OTHERSTAGES
+module load Stages/2023
+module load GCC/11.3.0
+module load ParaStationMPI/5.7.0-1
+#
+#module load Hypre/2.27.0
+module load Silo/4.11
+module load Tcl/8.6.12 
+#
+module load ecCodes/2.27.0
+module load HDF5/1.12.2-serial
+module load netCDF/4.9.0
+module load netCDF-Fortran/4.6.0
+module load PnetCDF/1.12.3
+module load cURL/7.83.0
+module load Szip/.2.1.1
+module load Python/3.10.4
+module load CMake/3.23.1
+
+module load GCCcore/.11.3.0
+module load Perl/5.34.1
+ 
+module li

--- a/bldsva/setup_tsmp.ksh
+++ b/bldsva/setup_tsmp.ksh
@@ -68,7 +68,7 @@ getDefaults(){
 setDefaults(){
   platform=$def_platform
   compiler=$def_compiler
-  if [[ $platform == "" ]] then ; platform="JUWELS" ; fi #We need a hard default here
+  if [[ $platform == "" ]] then ; platform="JEDI" ; fi #We need a hard default here
   version=$def_combination
   if [[ $version == "" ]] then ; version="" ; fi #We need a hard default here
   bindir=$def_bindir

--- a/bldsva/supported_versions.ksh
+++ b/bldsva/supported_versions.ksh
@@ -16,6 +16,7 @@ platforms+=(
         ["JUWELS"]="JSC (FZ-Juelich) - general purpose Linux Cluster"
         ["DEEP"]="JSC (FZ-Juelich) - general purpose Linux Cluster"
         ["JUSUF"]="JSC (FZ-Juelich) - general purpose Linux Cluster"
+        ["JEDI"]="JSC (FZ-Juelich) - general purpose Linux Cluster"
 )
 
 # list of available versions for a platform
@@ -30,6 +31,8 @@ availability+=(
         ["JUSUF"]=" clm3-cos4-pfl clm3-cos4-pfl-pdaf clm3-cos5-pfl clm4-cos4-pfl clm4-cos5-pfl clm3-cos5-pfl-pdaf clm3-icon21-pfl \
                      clm3-icon26-pfl eclm eclm-mct clm5-cos5-pfl clm5-cos5-pfl-pdaf "
         ["GENERIC_X86"]=" clm3-cos4-pfl clm3-cos4-pfl-pdaf clm3-cos5-pfl clm4-cos4-pfl clm4-cos5-pfl clm3-cos5-pfl-pdaf clm3-icon21-pfl \
+                     clm3-icon26-pfl eclm eclm-mct clm5-cos5-pfl clm5-cos5-pfl-pdaf "
+        ["JEDI"]=" clm3-cos4-pfl clm3-cos4-pfl-pdaf clm3-cos5-pfl clm4-cos4-pfl clm4-cos5-pfl clm3-cos5-pfl-pdaf clm3-icon21-pfl \
                      clm3-icon26-pfl eclm eclm-mct clm5-cos5-pfl clm5-cos5-pfl-pdaf "
 )
 
@@ -108,5 +111,6 @@ setupsAvail+=(
 	["JURECA"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex cordex0275 idealRTD idiurnal-cycle "
     ["DEEP"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex idealRTD "
 	["GENERIC_X86"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex idealRTD "
+	["JEDI"]=" nrw ideal300150 ideal600300 ideal1200600 ideal24001200 cordex cordex0275 idealRTD idiurnal-cycle "
 )
 


### PR DESCRIPTION
I added changes to TSMP1 to compile it on JEDI.
The build is with `Gnu` (no Intel on Jedi) and was successfully built for the combination of "clm3 + par flow CPU": 
`./build_tsmp.ksh -c clm3-pfl -m JEDI -O Gnu`
Currently, it's for Stages2024.

**Gnu fixes are based on**:
https://gitlab.jsc.fz-juelich.de/HPSCTerrSys/tsmp-internal-development-tracking/-/issues/65 

**Gnu fixes were on this branch**:
https://github.com/HPSCTerrSys/TSMP/tree/gnu_update

**Parflow needed to be updated too**:
"Remove multiple definitions of AMPS_CPU_TICKS_PER_SEC to be gcc compatible"
https://github.com/HPSCTerrSys/parflow/tree/gnu_fix