### PR TITLE
PDAF: Move `LINK_LIBS` to end of command

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/Makefile
+++ b/bldsva/intf_DA/pdaf/framework/Makefile
@@ -145,7 +145,7 @@ $(PROG) : $(LIBMODEL) libpdaf-d.a \
 	$(MODULES) $(MOD_ASSIM) $(OBJ_MODEL_PDAF) $(OBJ_PDAF_INT) $(OBJ_PDAF_USER) 
 	$(PREP_C) $(LD)  $(OPT_LNK)  -o $@ \
 	$(MODULES) $(MOD_ASSIM) $(OBJ_MODEL_PDAF) $(OBJ_PDAF_INT) $(OBJ_PDAF_USER) \
-	-L$(BASEDIR)/lib -lpdaf-d $(LINK_LIBS) $(LIBMODEL) $(LIBS)
+	-L$(BASEDIR)/lib -lpdaf-d $(LIBMODEL) $(LIBS) $(LINK_LIBS)
 
 ######################################################
 


### PR DESCRIPTION
`LINK_LIBS` contains the most general libraries and should therefore be moved to the end of the command.