### PR TITLE
PDAF: Introduce observation index transformation `obs_nc2pdaf`

### DIFF
--- a/bldsva/intf_DA/pdaf/framework/g2l_obs_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/g2l_obs_pdaf.F90
@@ -54,7 +54,7 @@ SUBROUTINE g2l_obs_pdaf(domain_p, step, dim_obs_f, dim_obs_l, mstate_f, &
 !
 ! !USES:
   USE mod_assimilation, &
-       ONLY: obs_index_l, m_id_f
+       ONLY: obs_index_l, obs_nc2pdaf_deprecated
 
   IMPLICIT NONE
 
@@ -86,11 +86,11 @@ SUBROUTINE g2l_obs_pdaf(domain_p, step, dim_obs_f, dim_obs_l, mstate_f, &
   mstate_l(:) = 0.0
 
   ! Set Obs. vector on local domain
-  ! Index array M_ID_F set in subroutine OBS_OP_F_PDAF
-  ! Index array OBS_INDEX_L set in subroutine INIT_DIM_OBS_L_PDAF
+  ! Index array OBS_NC2PDAF_DEPRECATED set in subroutine OBS_OP_F_PDAF
+  ! Index array OBS_INDEX_L (returns nc-ordered index) set in subroutine INIT_DIM_OBS_L_PDAF
   do i=1,dim_obs_l
     !mstate_l(i) = mstate_f(obs_index_l(i)) 
-    mstate_l(i) = mstate_f(m_id_f(obs_index_l(i)))
+    mstate_l(i) = mstate_f(obs_nc2pdaf_deprecated(obs_index_l(i)))
   end do
 
 END SUBROUTINE g2l_obs_pdaf

--- a/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/init_dim_obs_f_pdaf.F90
@@ -88,6 +88,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
        var_id_obs, maxlon, minlon, maxlat, &
        minlat, maxix, minix, maxiy, miniy, lon_var_id, ix_var_id, lat_var_id, iy_var_id, &
        screen
+  USE mod_assimilation, ONLY: obs_nc2pdaf
   Use mod_read_obs, &
        only: idx_obs_nc, pressure_obs, pressure_obserr, multierr, &
        read_obs_nc, clean_obs_nc, x_idx_obs_nc, y_idx_obs_nc, &
@@ -585,6 +586,9 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   if (allocated(obs_pdaf2nc)) deallocate(obs_pdaf2nc)
   allocate(obs_pdaf2nc(dim_obs))
   obs_pdaf2nc = 0
+  if (allocated(obs_nc2pdaf)) deallocate(obs_nc2pdaf)
+  allocate(obs_nc2pdaf(dim_obs))
+  obs_nc2pdaf = 0
 
 #ifndef CLMSA
 #ifndef OBS_ONLY_CLM
@@ -596,6 +600,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
       do j = 1, enkf_subvecsize
         if (idx_obs_nc(i) .eq. idx_map_subvec2state_fortran(j)) then
           obs_pdaf2nc(local_disp_obs(mype_filter+1)+cnt) = i
+          obs_nc2pdaf(i) = local_disp_obs(mype_filter+1)+cnt
           cnt = cnt + 1
         end if
       end do
@@ -627,6 +632,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
               if(((is_use_dr).and.(deltax.le.clmobs_dr(1)).and.(deltay.le.clmobs_dr(2))).or.((.not. is_use_dr).and.(longxy_obs(i) == longxy(g-begg+1)) .and. (latixy_obs(i) == latixy(g-begg+1)))) then
                 obs_pdaf2nc(local_disp_obs(mype_filter+1)+cnt) = i
+                obs_nc2pdaf(i) = local_disp_obs(mype_filter+1)+cnt
                 cnt = cnt + 1
               end if
 
@@ -646,6 +652,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   ! collect values from all PEs, by adding all PE-local arrays (works
   ! since only the subsection belonging to a specific PE is non-zero)
   call mpi_allreduce(MPI_IN_PLACE,obs_pdaf2nc,dim_obs,MPI_INTEGER,MPI_SUM,comm_filter,ierror)
+  call mpi_allreduce(MPI_IN_PLACE,obs_nc2pdaf,dim_obs,MPI_INTEGER,MPI_SUM,comm_filter,ierror)
 
   if (mype_filter==0 .and. screen > 2) then
       print *, "TSMP-PDAF mype(w)=", mype_world, ": init_dim_obs_pdaf: obs_pdaf2nc=", obs_pdaf2nc

--- a/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
@@ -92,7 +92,7 @@ MODULE mod_assimilation
                                           ! variables distributed over a grid surface area 
   !kuw
   INTEGER, ALLOCATABLE :: obs_id_p(:) ! ID of observation point in PE-local domain
-  INTEGER, ALLOCATABLE :: m_id_f(:)   ! index for mapping mstate to local domain
+  INTEGER, ALLOCATABLE :: obs_nc2pdaf_deprecated(:)   ! index for mapping mstate to local domain
   !kuw end
 
   ! Multi-scale DA

--- a/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
+++ b/bldsva/intf_DA/pdaf/framework/mod_assimilation.F90
@@ -93,6 +93,7 @@ MODULE mod_assimilation
   !kuw
   INTEGER, ALLOCATABLE :: obs_id_p(:) ! ID of observation point in PE-local domain
   INTEGER, ALLOCATABLE :: obs_nc2pdaf_deprecated(:)   ! index for mapping mstate to local domain
+  INTEGER, ALLOCATABLE :: obs_nc2pdaf(:)   ! index for mapping mstate to local domain
   !kuw end
 
   ! Multi-scale DA

--- a/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
@@ -122,12 +122,12 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
 
   ! Gather full observed state using local_dims_obs, local_disp_obs
 
-  ! gather local observed states of different sizes in a vector 
+  ! gather local observed states of different sizes in a vector
   CALL mpi_allgatherv(m_state_tmp, dim_obs_p, &
-       MPI_DOUBLE_PRECISION, m_state_f, local_dims_obs, local_disp_obs, &  
+       MPI_DOUBLE_PRECISION, m_state_f, local_dims_obs, local_disp_obs, &
        MPI_DOUBLE_PRECISION, comm_filter, ierror)
 
-  ! gather obs_nc2pdaf_deprecated_p 
+  ! gather obs_nc2pdaf_deprecated_p
   CALL mpi_allgatherv(obs_nc2pdaf_deprecated_p_tmp, dim_obs_p, &
        MPI_INT, obs_nc2pdaf_deprecated, local_dims_obs, local_disp_obs, &  
        MPI_INT, comm_filter, ierror)
@@ -144,11 +144,11 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
     end if
   end do
 
-  ! Then it is inverted in the following lines
-  
+  ! Then OBS_NC2PDAF_DEPRECATED is inverted in the following lines
+
   ! resort obs_nc2pdaf_deprecated_p
   do i=1,dim_obs_f
-     obs_nc2pdaf_deprecated_tmp(i) = obs_nc2pdaf_deprecated(i)     
+     obs_nc2pdaf_deprecated_tmp(i) = obs_nc2pdaf_deprecated(i)
   enddo
   do i=1,dim_obs_f
     ! print *,'obs_nc2pdaf_deprecated_tmp(i) ', obs_nc2pdaf_deprecated_tmp(i)

--- a/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
@@ -59,6 +59,7 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   USE mod_assimilation, &
        ONLY: obs_index_p, local_dims_obs, local_disp_obs, obs_id_p, obs_nc2pdaf_deprecated, &
        var_id_obs, dim_obs_p
+  USE mod_assimilation, ONLY: obs_pdaf2nc
   USE mod_parallel_pdaf, &
        ONLY: mype_world, mype_filter, npes_filter, comm_filter, MPI_DOUBLE, &
        MPI_DOUBLE_PRECISION, MPI_INT, MPI_SUM, abort_parallel
@@ -132,6 +133,15 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
 
   ! At this point OBS_NC2PDAF_DEPRECATED should be the same as OBS_PDAF2NC from
   ! INIT_DIM_OBS_PDAF / INIT_DIM_OBS_F_PDAF
+  do i = 1, dim_obs_f
+    if(.not. obs_nc2pdaf_deprecated(i) .eq. obs_pdaf2nc(i)) then
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR in observation index arrays"
+      print *, "i=", i
+      print *, "obs_nc2pdaf_deprecated(i)=", obs_nc2pdaf_deprecated(i)
+      print *, "obs_pdaf2nc(i)=", obs_pdaf2nc(i)
+      call abort_parallel()
+    end if
+  end do
 
   ! Then it is inverted in the following lines
   

--- a/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
+++ b/bldsva/intf_DA/pdaf/framework/obs_op_f_pdaf.F90
@@ -60,6 +60,7 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
        ONLY: obs_index_p, local_dims_obs, local_disp_obs, obs_id_p, obs_nc2pdaf_deprecated, &
        var_id_obs, dim_obs_p
   USE mod_assimilation, ONLY: obs_pdaf2nc
+  USE mod_assimilation, ONLY: obs_nc2pdaf
   USE mod_parallel_pdaf, &
        ONLY: mype_world, mype_filter, npes_filter, comm_filter, MPI_DOUBLE, &
        MPI_DOUBLE_PRECISION, MPI_INT, MPI_SUM, abort_parallel
@@ -153,6 +154,18 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
     ! print *,'obs_nc2pdaf_deprecated_tmp(i) ', obs_nc2pdaf_deprecated_tmp(i)
      obs_nc2pdaf_deprecated(obs_nc2pdaf_deprecated_tmp(i)) = i
   enddo
+
+  ! At this point OBS_NC2PDAF_DEPRECATED should be the same as OBS_NC2PDAF from
+  ! INIT_DIM_OBS_PDAF / INIT_DIM_OBS_F_PDAF
+  do i = 1, dim_obs_f
+    if(.not. obs_nc2pdaf_deprecated(i) .eq. obs_nc2pdaf(i)) then
+      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR in observation index arrays"
+      print *, "i=", i
+      print *, "obs_nc2pdaf_deprecated(i)=", obs_nc2pdaf_deprecated(i)
+      print *, "obs_nc2pdaf(i)=", obs_nc2pdaf(i)
+      call abort_parallel()
+    end if
+  end do
 
   ! Clean up
   DEALLOCATE(m_state_tmp,obs_nc2pdaf_deprecated_p_tmp,obs_nc2pdaf_deprecated_tmp)


### PR DESCRIPTION
Only used in local filters (except LEnKF).
- renaming `m_id_f` to `obs_nc2pdaf_deprecated` in order to incorporate it in a common naming scheme.
- filling `obs_nc2pdaf` in observation dimension initialization routines (`init_dim_obs_*.F90`)
- testing `obs_nc2pdaf_deprecated` against `obs_nc2pdaf` to ensure that the latter may actually replace the former.

TODO at later stage (especially with testcase for LETKF ready): remove  `obs_nc2pdaf_deprecated`.